### PR TITLE
fix: Use target_directory configuration as save destination

### DIFF
--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Annotated
 
 import aiohttp
@@ -83,7 +82,7 @@ async def main(  # noqa: PLR0913 (too many arguments because of typer)
         headers=await parse_auth_header(auth_header),
         cookie_jar=await parse_session_cookie(cookie_string),
     ) as session:
-        destionation_directory = config.downloading_settings.target_directory.absolute()
+        destination_directory = config.downloading_settings.target_directory.absolute()
         boosty_api_client = BoostyAPIClient(
             RetryClient(session, retry_options=retry_options),
         )

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -83,7 +83,7 @@ async def main(  # noqa: PLR0913 (too many arguments because of typer)
         headers=await parse_auth_header(auth_header),
         cookie_jar=await parse_session_cookie(cookie_string),
     ) as session:
-        destination_directory = Path('./boosty-downloads').absolute()
+        destionation_directory = config.downloading_settings.target_directory.absolute()
         boosty_api_client = BoostyAPIClient(
             RetryClient(session, retry_options=retry_options),
         )


### PR DESCRIPTION
# 📌 Fix `target_directory` config does not used
## 📝 Description  
Template config file `config.yaml` provides setting for target directory to store downloaded files, but code used hardcoded default path instead.

## 🔄 Changelog  
 
- **🛠 Fixed:** `target_directory` config line does not used

## ✅ Checklist  

- [X] Locally tested (`make test` and your own judgment)
- [ ] Documentation updated (if necessary) 
- [ ] Code follows the project's style guidelines (`make lint && make format`)
