### PR TITLE
fix(boosty): 🐛 make image dto width/height optional to avoid validati…

### DIFF
--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -103,6 +103,7 @@ class DownloadPostByUrlUseCase:
                         self.context.progress_reporter.error(
                             f'Failed to download post: {e.message}, RESOURCE: ({e.resource})'
                         )
+                    else:
                         return
 
         self.context.progress_reporter.error(

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_image.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_image.py
@@ -10,5 +10,5 @@ class BoostyPostDataImageDTO(BaseModel):
 
     type: Literal['image']
     url: str
-    width: int
-    height: int
+    width: int | None = None
+    height: int | None = None


### PR DESCRIPTION
## 📝 Description  

Make `width` and `height` in `BoostyPostDataImageDTO` optional to prevent validation errors with the latest Boosty API.  
Also fixed the search logic so it stops after downloading a specific post.

## 🔄 Changelog  

- **🛠 Fixed:** Image DTO validation errors  
- **🛠 Fixed:** Search stopping after specific post  

## 🎯 Related Issue  
Closes #<issue-number>  

## ✅ Checklist  

- [x] Tested locally  
- [x] Code style checks passed (`make lint && make format`)  
