### PR TITLE
audio support, html rendering, stability, speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,29 @@ The post content itself is saved in html with a little bit of styling.
 - Files
 - Full Post content (including photos and links)
 
+## Changes in this fork
+
+### Fixes
+
+* support for audio in posts, including HTML rendering
+* disabled giant tracebacks on errors
+* videos in HTML render correctly
+* faster walk through pages
+* retries with actual delay to compensate for unstable APIs and network
+* fully downloaded files are never downloaded again, even if app crashed, cache cleared, etc
+
+### Features
+
+* page progress is stored in `username/last.offset` file for fast resume, delete it to start from 1st page
+* External videos are not downloaded with yt-dlp anymore: it requires js runtime, auth, cookies, error handling. instead, youtube urls are saved to `.yt` files for manual processing
+* create `ignore_me` file inside any post to skip it - a workaround if you have a post that breaks downloading
+* 
+
 ## 📑 Table of Contents
 - [🖥️ About](#️-about)
+  - [Changes in this fork](#changes-in-this-fork)
+    - [Fixes](#fixes)
+    - [Features](#features)
   - [📑 Table of Contents](#-table-of-contents)
   - [✨ Features](#-features)
   - [📸 Screenshots \& Usage](#-screenshots--usage)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The post content itself is saved in html with a little bit of styling.
 * faster walk through pages
 * retries with actual delay to compensate for unstable APIs and network
 * fully downloaded files are never downloaded again, even if app crashed, cache cleared, etc
+* multiple boosty videos in a post do not overwrite each other
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,21 @@ The post content itself is saved in html with a little bit of styling.
 * page progress is stored in `username/last.offset` file for fast resume, delete it to start from 1st page
 * External videos are not downloaded with yt-dlp anymore: it requires js runtime, auth, cookies, error handling. instead, youtube urls are saved to `.yt` files for manual processing
 * create `ignore_me` file inside any post to skip it - a workaround if you have a post that breaks downloading
-* 
+
+### Deal with Youtube
+
+Example script to download all videos from `.yt` files and place them in the same folder. They won't be displayed in HTML though.
+
+* you need to install yt-dlp dependencies
+* provide youtube cookies
+* `yt-archive.txt` file will be used to skip downloaded videos
+* customize format and other parameters to speed up downloads, change output, etc
+* `--paths home:` sets yt-dlp output path to a directory of currently processing file
+
+```bash
+find . -type f -name '*.yt' | while read x ; do echo "DOWNLOADING video from file ${x} to ${x%/*}"; yt-dlp -t mkv --cookies cookies.txt --download-archive yt-archive.txt -a "$x" --paths "home:${x%/*}"; done
+```
+
 
 ## 📑 Table of Contents
 - [🖥️ About](#️-about)

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ The post content itself is saved in html with a little bit of styling.
 
 ### Deal with Youtube
 
-Example script to download all videos from `.yt` files and place them in the same folder. They won't be displayed in HTML though.
+Example script to download all videos from `.yt` files and place them in the same folder. They will be picked up by HTML post.
 
 * you need to install yt-dlp dependencies
 * provide youtube cookies
 * `yt-archive.txt` file will be used to skip downloaded videos
 * customize format and other parameters to speed up downloads, change output, etc
-* `--paths home:` sets yt-dlp output path to a directory of currently processing file
+* `--paths home:` sets yt-dlp output path for result and temp files to current_post/external_video
+* `--postprocessor-args` is a fix for random fails in ffmpeg mkv conversion
 
 ```bash
-find . -type f -name '*.yt' | while read x ; do echo "DOWNLOADING video from file ${x} to ${x%/*}"; yt-dlp -t mkv --cookies cookies.txt --download-archive yt-archive.txt -a "$x" --paths "home:${x%/*}"; done
+find . -type f -name '*.yt' | sort -r | while read x ; do echo "DOWNLOADING ${x%/*}/${x##*/}.mkv"; yt-dlp -t mkv --cookies cookies.txt --download-archive yt-archive.txt -f "best[height<=720]" -a "$x" --paths "home:${x%/*}" -o "${x##*/}.mkv" --postprocessor-args "VideoRemuxer+ffmpeg:-bsf 'setts=ts=TS-STARTPTS'" || break; done
 ```
 
 
@@ -53,6 +54,7 @@ find . -type f -name '*.yt' | while read x ; do echo "DOWNLOADING video from fil
   - [Changes in this fork](#changes-in-this-fork)
     - [Fixes](#fixes)
     - [Features](#features)
+    - [Deal with Youtube](#deal-with-youtube)
   - [📑 Table of Contents](#-table-of-contents)
   - [✨ Features](#-features)
   - [📸 Screenshots \& Usage](#-screenshots--usage)

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -80,6 +80,7 @@ typer_app = typer.Typer(
     no_args_is_help=True,
     add_completion=False,
     rich_markup_mode='rich',
+    pretty_exceptions_enable=False
 )
 
 GITHUB_ISSUES_URL = 'https://github.com/Glitchy-Sheep/boosty-downloader/issues'

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -133,7 +133,9 @@ async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typ
         config.downloading_settings.target_directory = destination_directory
 
     retry_options = ExponentialRetry(
-        attempts=5,
+        attempts=10,
+        start_timeout=2,
+        max_timeout=10000,
         exceptions={
             aiohttp.ClientConnectorError,
             aiohttp.ClientOSError,

--- a/boosty_downloader/src/application/mappers/file.py
+++ b/boosty_downloader/src/application/mappers/file.py
@@ -3,11 +3,12 @@
 from boosty_downloader.src.domain.post import PostDataChunkFile
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types import (
     BoostyPostDataFileDTO,
+    BoostyPostDataAudioDTO,
 )
 
 
 def to_domain_file_chunk(
-    api_file: BoostyPostDataFileDTO, signed_query: str
+    api_file: BoostyPostDataFileDTO | BoostyPostDataAudioDTO, signed_query: str
 ) -> PostDataChunkFile:
     """Convert API PostDataFile to domain PostDataChunkFile."""
     return PostDataChunkFile(

--- a/boosty_downloader/src/application/mappers/html_converter.py
+++ b/boosty_downloader/src/application/mappers/html_converter.py
@@ -1,5 +1,7 @@
 """Converters from domain models to HTML generator models."""
 
+import urllib.parse
+from pathlib import Path
 from boosty_downloader.src.domain.post import (
     PostDataChunkImage,
     PostDataChunkText,
@@ -46,15 +48,16 @@ def convert_image_to_html(chunk: PostDataChunkImage) -> HtmlGenImage:
     return HtmlGenImage(url=chunk.url)
 
 
-def convert_video_to_html(src: str, title: str) -> HtmlGenVideo:
+def convert_video_to_html(src: str, title: str, yt:str|None=None) -> HtmlGenVideo:
     """Convert domain video chunk to HTML video model."""
-    return HtmlGenVideo(url=src, title=title)
+    return HtmlGenVideo(url=src, title=title, yt=yt)
 
 
-def convert_file_to_html(chunk: PostDataChunkFile) -> HtmlGenFile:
+def convert_file_to_html(chunk: PostDataChunkFile, relative_path: Path) -> HtmlGenFile:
     """Convert domain file chunk to HTML file model."""
+    # url is useless, its original address
+    chunk.url = fix_path(relative_path)
     return HtmlGenFile(url=chunk.url, filename=chunk.filename)
-
 
 def convert_list_to_html(chunk: PostDataChunkTextualList) -> HtmlGenList:
     """Convert domain list chunk to HTML list model."""
@@ -69,3 +72,7 @@ def convert_list_to_html(chunk: PostDataChunkTextualList) -> HtmlGenList:
     style = HtmlListStyle.UNORDERED
 
     return HtmlGenList(items=items, style=style)
+
+def fix_path(path: Path):
+    x = str(path).replace('\\', '/')
+    return urllib.parse.quote(x)

--- a/boosty_downloader/src/application/mappers/post_mapper.py
+++ b/boosty_downloader/src/application/mappers/post_mapper.py
@@ -15,6 +15,7 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
     BoostyPostDataListDTO,
     BoostyPostDataOkVideoDTO,
     BoostyPostDataTextDTO,
+    BoostyPostDataAudioDTO,
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_ok_video import (
     BoostyOkVideoType,
@@ -49,7 +50,10 @@ def map_post_dto_to_domain(
                 post.post_data_chunks.append(text_chunk)
             case BoostyPostDataListDTO():
                 post.post_data_chunks.append(mappers.to_domain_list_chunk(data_chunk))
-            case BoostyPostDataFileDTO():
+            case (
+                BoostyPostDataFileDTO()
+                | BoostyPostDataAudioDTO()
+            ):
                 post.post_data_chunks.append(
                     mappers.to_domain_file_chunk(data_chunk, post.signed_query)
                 )

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -42,7 +42,7 @@ class DownloadAllPostUseCase:
 
     async def execute(self) -> None:
         posts_iterator = self.boosty_api.iterate_over_posts(
-            author_name=self.author_name
+            author_name=self.author_name, posts_per_page=20, destination=self.destination
         )
 
         current_page = 0
@@ -87,7 +87,7 @@ class DownloadAllPostUseCase:
                     description=f'Processing page [bold]{current_page}[/bold]',
                 )
 
-                max_attempts = 5
+                max_attempts = 6
                 delay = 1.0
                 for attempt in range(1, max_attempts + 1):
                     try:
@@ -108,7 +108,7 @@ class DownloadAllPostUseCase:
                                 f'Retrying in {delay:.1f}s... ({e.message})'
                             )
                             await asyncio.sleep(delay)
-                            delay = min(delay * 1.5, 10.0)
+                            delay = delay * 2
 
             self.context.progress_reporter.complete_task(page_task_id)
             self.context.progress_reporter.success(

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
@@ -30,8 +30,8 @@ BasePostData = Annotated[
     | BoostyPostDataExternalVideoDTO
     | BoostyPostDataOkVideoDTO
     | BoostyPostDataHeaderDTO
-    | BoostyPostDataListDTO
-    | BoostyPostDataAudioDTO,
+    | BoostyPostDataAudioDTO
+    | BoostyPostDataListDTO,
     Field(
         discriminator='type',
     ),

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
@@ -19,6 +19,7 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
     BoostyPostDataListDTO,
     BoostyPostDataOkVideoDTO,
     BoostyPostDataTextDTO,
+    BoostyPostDataAudioDTO,
 )
 
 BasePostData = Annotated[
@@ -29,7 +30,8 @@ BasePostData = Annotated[
     | BoostyPostDataExternalVideoDTO
     | BoostyPostDataOkVideoDTO
     | BoostyPostDataHeaderDTO
-    | BoostyPostDataListDTO,
+    | BoostyPostDataListDTO
+    | BoostyPostDataAudioDTO,
     Field(
         discriminator='type',
     ),

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/__init__.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/__init__.py
@@ -6,6 +6,7 @@ from .post_data_list import BoostyPostDataListDTO
 from .post_data_ok_video import BoostyPostDataOkVideoDTO
 from .post_data_text import BoostyPostDataTextDTO
 from .post_data_video import BoostyPostDataExternalVideoDTO
+from .post_data_audio import BoostyPostDataAudioDTO
 
 __all__ = [
     'BoostyPostDataExternalVideoDTO',
@@ -16,4 +17,5 @@ __all__ = [
     'BoostyPostDataListDTO',
     'BoostyPostDataOkVideoDTO',
     'BoostyPostDataTextDTO',
+    'BoostyPostDataAudioDTO',
 ]

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_audio.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_audio.py
@@ -1,0 +1,13 @@
+"""The module with file representation of audio data"""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class BoostyPostDataAudioDTO(BaseModel):
+    """Audio content piece in posts"""
+
+    type: Literal['audio_file']
+    url: str
+    title: str

--- a/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
+++ b/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
@@ -11,6 +11,7 @@ from typing import Any, ClassVar, cast
 
 from yt_dlp.YoutubeDL import YoutubeDL
 from yt_dlp.utils import DownloadError
+import base64
 
 YtDlOptions = dict[str, object]
 ExternalVideoDownloadProgressHook = Callable[['ExternalVideoDownloadStatus'], None]
@@ -102,6 +103,14 @@ class ExternalVideosDownloader:
         progress_hook: ExternalVideoDownloadProgressHook | None = None,
     ) -> Path:
         """Download video using yt-dlp and repeatedly report progress via progress_hook callback until completion."""
+        destination_directory.mkdir(parents=True, exist_ok=True)
+        name = base64.urlsafe_b64encode(url.encode('utf-8')).decode('utf-8') + '.yt'
+        f = destination_directory / name
+        with f.open('w', encoding='utf-8') as file:
+            file.write(url)
+        return f
+    
+        raise Exception(f"yt-dlp requires updates, js runtime and cookies")
         info = self._probe_video(url)
         title = info.get('title')
         if not isinstance(title, str) or not title.strip():

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -134,9 +134,12 @@ async def download_file(
                 file_path = file_path.with_suffix(ext)
 
 
-        if file_path.exists() and file_path.stat().st_size == response.content_length:
-            #print(f'File exists and size is right, skip download: {file_path}')
-            return file_path
+        if file_path.exists():
+            if file_path.stat().st_size == response.content_length:
+                #print(f'File exists and size is right, skip download: {file_path}')
+                return file_path
+            #else:
+            #    print(f'File exists but size is wrong: {file_path} {file_path.stat().st_size}, EXPECTED {response.content_length}')
 
         total_downloaded = 0
         async with aiofiles.open(file_path, mode='wb') as file:

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -133,12 +133,17 @@ async def download_file(
             if ext is not None:
                 file_path = file_path.with_suffix(ext)
 
-        total_downloaded = 0
 
+        if file_path.exists() and file_path.stat().st_size == response.content_length:
+            #print(f'File exists and size is right, skip download: {file_path}')
+            return file_path
+
+        total_downloaded = 0
         async with aiofiles.open(file_path, mode='wb') as file:
             total_size = response.content_length
 
             try:
+                # sometimes fails with ContentLengthError: 400 Not enough data to satisfy content length header
                 async for chunk in response.content.iter_chunked(
                     dl_config.chunk_size_bytes
                 ):

--- a/boosty_downloader/src/infrastructure/html_generator/models.py
+++ b/boosty_downloader/src/infrastructure/html_generator/models.py
@@ -49,6 +49,7 @@ class HtmlGenVideo:
     url: str
     title: str | None = None
     poster: str | None = None
+    yt: str | None = None
 
 
 class HtmlListStyle(Enum):

--- a/boosty_downloader/src/infrastructure/html_generator/renderer.py
+++ b/boosty_downloader/src/infrastructure/html_generator/renderer.py
@@ -45,8 +45,9 @@ def render_html_chunk(chunk: HtmlGenChunk) -> str:
                 lst=chunk, render_chunk=render_html_chunk
             )
         case HtmlGenFile():
+            if Path(chunk.filename.lower()).suffix in ('.mp3', '.ogg', '.wav'):
+                return f'<p>{chunk.filename} <audio controls><source src="{chunk.url}">Your browser does not support the audio element.</audio></p>'
             return f'<a href="{chunk.url}" download>{chunk.filename}</a>'
-
 
 def render_html(chunks: list[HtmlGenChunk]) -> str:
     """Render a list of HTML chunks to HTML."""

--- a/boosty_downloader/src/infrastructure/html_generator/templates/video.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/video.html
@@ -1,4 +1,8 @@
+{% if video.yt %}
+    <p>youtube: <a href="{{ video.yt }}">{{ video.yt }}</a> - make local copy with yt-dlp yourself</p>
+{% else %}
 <video controls>
-    <source src="{{ video.url }}" type="video/mp4">
+    <source src="{{ video.url|urlencode }}" type="video/mp4">
     Your browser does not support the video tag.
 </video>
+{% endif %}

--- a/boosty_downloader/src/infrastructure/html_generator/templates/video.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/video.html
@@ -1,5 +1,9 @@
 {% if video.yt %}
-    <p>youtube: <a href="{{ video.yt }}">{{ video.yt }}</a> - make local copy with yt-dlp yourself</p>
+<p>youtube: <a href="{{ video.yt }}">{{ video.yt }}</a> - video will appear below if you make a local copy with yt-dlp</p>
+<video controls>
+    <source src="{{ video.url|urlencode }}.mkv" type="video/mp4">
+    Your browser does not support the video tag.
+</video>
 {% else %}
 <video controls>
     <source src="{{ video.url|urlencode }}" type="video/mp4">


### PR DESCRIPTION
# 📌 Fixed #61 #74 #76

All changes described here:

https://github.com/Rast1234/boosty-downloader?tab=readme-ov-file#changes-in-this-fork

## 📝 Description  

* Not crashing when downloading everything
* Audio gets downloaded as files, with HTML rendering
* Request retries had default exponent 0.1 seconds with 5 attempts, meaning timeouts `[0.1, 0.2, 0.4, 0.8, 1.6]` which was useless and lead to a lot of skipped/interrupted downloads. Now it's `[2, 4, 8, ..., 1024]` seconds. Also fixed retries in another place
* Disable yt-dlp because it's impossible to support reliably. instead, save video URLs to files to download manually
* A way to skip any bugged post by creating a file in post folder
* Fast resume because page offset is stored
* Already downloaded files are never downloaded again if content-length matches file size
* Multiple boosty videos in a post are downloaded correctly and not into same filename