### PR TITLE
Fix: Handle empty post titles with consistent fallback

### DIFF
--- a/boosty_downloader/src/application/mappers/post_mapper.py
+++ b/boosty_downloader/src/application/mappers/post_mapper.py
@@ -27,7 +27,7 @@ def map_post_dto_to_domain(
     """Convert a Boosty API PostDTO object to a domain Post object, mapping all data chunks to their domain representations."""
     post = Post(
         uuid=post_dto.id,
-        title=post_dto.title,
+        title=post_dto.title if post_dto.title else f'Not title (id_{post_dto.id[:8]})',
         created_at=post_dto.created_at,
         updated_at=post_dto.updated_at,
         has_access=post_dto.has_access,

--- a/boosty_downloader/src/application/use_cases/check_total_posts.py
+++ b/boosty_downloader/src/application/use_cases/check_total_posts.py
@@ -49,7 +49,11 @@ class ReportTotalPostsCountUseCase:
                     accessible_posts_count += 1
                 else:
                     inaccessible_posts_count += 1
-                    inaccessible_posts_names.append('     - ' + post.title + '\n')
+                    inaccessible_posts_names.append(
+                        '     - ' + post.title
+                        if post.title
+                        else f'Not title (id_{post.id[:8]})' + '\n'
+                    )
 
         inaccessible_titles_str = ''.join(inaccessible_posts_names)
 

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -65,7 +65,7 @@ class DownloadAllPostUseCase:
                     continue
 
                 # For empty titles use post ID as a fallback (first 8 chars)
-                if len(post_dto.title) == 0:
+                if not post_dto.title or len(post_dto.title) == 0:
                     post_dto.title = f'Not title (id_{post_dto.id[:8]})'
 
                 post_dto.title = (

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -86,7 +86,12 @@ class DownloadPostByUrlUseCase:
                         f'Found post with UUID: {post_uuid}, starting download...'
                     )
 
-                    post_name = f'{post.created_at.date()} - {post.title}'
+                    if not post.title or len(post.title) == 0:
+                        post.title = f'Not title (id_{post.id[:8]})'
+
+                    post_name = (
+                        f'{post.created_at.date()} - {post.title} ({post.id[:8]})'
+                    )
                     post_name = sanitize_string(post_name).replace('.', '').strip()
 
                     try:

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
@@ -17,7 +17,7 @@ class PostDTO(BaseModel):
     """Post on boosty.to which also have data pieces"""
 
     id: str
-    title: str
+    title: str | None = None
     created_at: datetime
     updated_at: datetime
     has_access: bool


### PR DESCRIPTION
# 📌 Fix: Handle empty post titles with consistent fallback

## 📝 Description  

Posts with empty or missing title fields from the Boosty API were causing inconsistent behavior across different use cases (downloading, reporting, etc.), and triggering Pydantic validation errors when title was None.  

This PR introduces a unified fallback mechanism that generates a consistent placeholder title using the post ID (first 8 characters) whenever the title is empty or missing. The fix is applied at multiple layers to ensure all parts of the application handle empty titles the same way.

**Changes include:**
- Updated `PostDTO` model to allow `title` to be optional (`str | None`).
- Modified the `post_mapper` to apply the fallback during domain object creation.
- Applied the same fallback logic in download and reporting use cases for consistency.
- Resolved the Pydantic validation error that occurred when `title` was `None`.

## 🔄 Changelog  

- **🛠 Fixed:** Pydantic validation error when Boosty API returns `null` for post title.
- **🔄 Changed:** `PostDTO.title` field is now optional (`str | None`).
- **✨ Added:** Consistent fallback title generation (`"Not title (id_{post_id[:8]})"`) across all use cases.
- **🔄 Changed:** Updated `download_all_posts`, `download_specific_post`, and `check_total_posts` use cases to use the same fallback logic.

## 🎯 Related Issue  
Closes #78

## ✅ Checklist  

- [x] Locally tested (`make test` and your own judgment)
- [x] Documentation updated (if necessary) 
- [x] Code follows the project's style guidelines (`make lint && make format`)  
