### PR TITLE
fix(downloader): truncate dirname to fit byte limit

### DIFF
--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -74,6 +74,7 @@ class DownloadAllPostUseCase:
 
                 # date - TITLE (UUID_PART) for deduplication in case of same names with different posts
                 full_post_title = f'{post_dto.created_at.date()} - {post_dto.title} ({post_dto.id[:8]})'
+                full_post_title = sanitize_string(full_post_title, max_bytes=240)
 
                 single_post_use_case = DownloadSinglePostUseCase(
                     destination=self.destination / full_post_title,

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -87,7 +87,11 @@ class DownloadPostByUrlUseCase:
                     )
 
                     post_name = f'{post.created_at.date()} - {post.title}'
-                    post_name = sanitize_string(post_name).replace('.', '').strip()
+                    post_name = (
+                        sanitize_string(post_name, max_bytes=240)
+                        .replace('.', '')
+                        .strip()
+                    )
 
                     try:
                         await DownloadSinglePostUseCase(

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -124,7 +124,7 @@ async def download_file(
                 response_message=response.reason or 'No reason provided',
             )
 
-        filename = sanitize_string(dl_config.filename)
+        filename = sanitize_string(dl_config.filename, max_bytes=230)
         file_path = dl_config.destination / filename
 
         content_type = response.content_type

--- a/boosty_downloader/src/infrastructure/path_sanitizer.py
+++ b/boosty_downloader/src/infrastructure/path_sanitizer.py
@@ -3,8 +3,16 @@
 import re
 
 
-def sanitize_string(string: str) -> str:
-    """Remove unsafe filesystem characters from a string"""
+def sanitize_string(string: str, max_bytes: int = 200) -> str:
+    """Remove unsafe filesystem characters from a string and truncate to fit byte limit"""
     # Convert path to a string and sanitize it
     unsafe_chars = r'[<>:"/\\|?*]'
-    return re.sub(unsafe_chars, '', str(string))
+    sanitized = re.sub(unsafe_chars, '', str(string))
+
+    if len(sanitized.encode('utf-8')) > max_bytes:
+        sanitized = sanitized.encode('utf-8')[:max_bytes].decode(
+            'utf-8', errors='ignore'
+        )
+        sanitized = sanitized.rstrip()
+
+    return sanitized

--- a/test/unit/path_sanitizer/path_sanitizer_test.py
+++ b/test/unit/path_sanitizer/path_sanitizer_test.py
@@ -1,0 +1,146 @@
+from boosty_downloader.src.infrastructure.path_sanitizer import sanitize_string
+
+
+def test_sanitize_string_removes_unsafe_characters():
+    unsafe_input = 'test<file>name:with/unsafe\\chars|and?more*'
+    result = sanitize_string(unsafe_input)
+
+    assert result == 'testfilenamewithunsafecharsandmore'
+
+
+def test_sanitize_string_preserves_safe_characters():
+    safe_input = 'Valid_File-Name 123 (test)'
+    result = sanitize_string(safe_input)
+
+    assert result == safe_input
+
+
+def test_sanitize_string_handles_empty_string():
+    result = sanitize_string('')
+
+    assert result == ''
+
+
+def test_sanitize_string_handles_only_unsafe_characters():
+    result = sanitize_string('<>:"/\\|?*')
+
+    assert result == ''
+
+
+def test_sanitize_string_truncates_long_strings():
+    long_string = 'a' * 300
+    result = sanitize_string(long_string)
+
+    assert len(result.encode('utf-8')) <= 200
+    assert len(result) == 200  # ASCII characters are 1 byte each
+
+
+def test_sanitize_string_custom_max_bytes():
+    long_string = 'a' * 150
+    result = sanitize_string(long_string, max_bytes=100)
+
+    assert len(result.encode('utf-8')) <= 100
+    assert len(result) == 100
+
+
+def test_sanitize_string_handles_utf8_multibyte_characters():
+    cyrillic_text = 'Привет мир' * 20  # ~200 bytes
+    result = sanitize_string(cyrillic_text, max_bytes=100)
+
+    assert len(result.encode('utf-8')) <= 100
+    result.encode('utf-8').decode('utf-8')
+
+
+def test_sanitize_string_handles_emojis():
+    emoji_text = '❤️' * 60  # ~240 bytes
+    result = sanitize_string(emoji_text, max_bytes=100)
+
+    assert len(result.encode('utf-8')) <= 100
+    result.encode('utf-8').decode('utf-8')
+
+
+def test_sanitize_string_mixed_multibyte_and_unsafe_chars():
+    mixed_text = 'Это пример простого русского текста для демонстрации. ❤️'
+    result = sanitize_string(mixed_text, max_bytes=50)
+
+    assert '/' not in result
+    assert len(result.encode('utf-8')) <= 50
+
+
+def test_sanitize_string_preserves_utf8_character_boundaries():
+    # Cyrillic 'Я' is 2 bytes (0xD0 0xAF in UTF-8)
+    text = 'a' * 99 + 'Я' * 10  # 99 + 20 = 119 bytes
+    result = sanitize_string(text, max_bytes=100)
+
+    try:
+        result.encode('utf-8').decode('utf-8')
+        valid_utf8 = True
+    except UnicodeDecodeError:
+        valid_utf8 = False
+
+    assert valid_utf8
+    assert len(result.encode('utf-8')) <= 100
+
+
+def test_sanitize_string_strips_trailing_whitespace_after_truncation():
+    text = 'a' * 95 + '     ' + 'b' * 100  # 200+ bytes
+    result = sanitize_string(text, max_bytes=100)
+
+    assert not result.endswith(' ')
+
+
+def test_sanitize_string_real_world_scenario():
+    long_title = (
+        'Это пример простого русского текста для демонстрации. '
+        'Он содержит буквы, цифры 123 и знаки препинания и эмоджи. ❤️ '
+        'Не несет никакой смысловой нагрузки (100%) 🔥'
+    )
+    full_path = f'2025-06-13 - {long_title} (12345f12)'
+    result = sanitize_string(full_path, max_bytes=240)
+
+    assert len(result.encode('utf-8')) <= 240
+    result.encode('utf-8').decode('utf-8')
+    assert len(result) > 0
+
+
+def test_sanitize_string_short_string_not_truncated():
+    short_text = 'Short Title'
+    result = sanitize_string(short_text, max_bytes=200)
+
+    assert result == short_text
+
+
+def test_sanitize_string_exactly_at_limit():
+    text = 'a' * 200
+    result = sanitize_string(text, max_bytes=200)
+
+    assert result == text
+    assert len(result.encode('utf-8')) == 200
+
+
+def test_sanitize_string_one_byte_over_limit():
+    text = 'a' * 201
+    result = sanitize_string(text, max_bytes=200)
+
+    assert len(result) == 200
+    assert len(result.encode('utf-8')) == 200
+
+
+def test_sanitize_string_default_max_bytes():
+    long_text = 'b' * 300
+    result = sanitize_string(long_text)
+
+    assert len(result.encode('utf-8')) <= 200
+    assert len(result) == 200
+
+
+def test_sanitize_string_handles_mixed_safe_and_unsafe():
+    mixed = 'Valid<Text>Привет/World❤️|Test' * 10
+    result = sanitize_string(mixed, max_bytes=100)
+
+    assert '<' not in result
+    assert '>' not in result
+    assert '/' not in result
+    assert '|' not in result
+    result.encode('utf-8').decode('utf-8')
+    assert len(result.encode('utf-8')) <= 100


### PR DESCRIPTION
# 📌 Task  <!-- Rename this to some general header, for example: "Fix bug X" -->

## 📝 Description  

Please run the following command
```
mkdir '/tmp/boosty/test/2022-22-22 - This is an example of simple text message for demonstration.                                
 🔥 It contains letters, numbers 123, and punctuation marks and emojis.❤️                                   
It carries no semantic meaning (100%)'
```

to see this error:
```
mkdir: cannot create directory ‘/tmp/boosty/test/2022-22-22 - This is an example of simple text message for demonstration.
🔥 It contains letters, numbers 123, and punctuation marks and emojis. ❤️  
It carries no semantic meaning (100%)’: File name too long
```

## ✅ Checklist  

- [x] Locally tested (`make test` and your own judgment)
- [ ] Documentation updated (if necessary) 
- [x] Code follows the project's style guidelines (`make lint && make format`)
