### PR TITLE
Fix incomplete videos downloading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Fix crash when processing unfinished uploads; they are now skipped gracefully
+
 ## 2.1.0
 
 - Added support for audio downloading and html rendering 

--- a/boosty_downloader/src/application/mappers/__init__.py
+++ b/boosty_downloader/src/application/mappers/__init__.py
@@ -16,9 +16,10 @@ from .image import to_domain_image_chunk
 from .link_header_text import to_domain_text_chunk
 from .list import to_domain_list_chunk
 from .ok_boosty_video import to_ok_boosty_video_content
-from .post_mapper import map_post_dto_to_domain
+from .post_mapper import PostMappingResult, map_post_dto_to_domain
 
 __all__ = [
+    'PostMappingResult',
     'get_best_video',
     'get_quality_ranking',
     'map_post_dto_to_domain',

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
@@ -49,6 +49,6 @@ class BoostyPostDataOkVideoDTO(BoostyBaseDTO):
     failover_host: str
     duration: timedelta
 
-    upload_status: str
+    upload_status: str | None = None
     complete: bool
     player_urls: list[BoostyOkVideoUrl]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boosty-downloader"
-version = "2.1.0"
+version = "2.1.1"
 description = ""
 authors = [
     { name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" },
@@ -40,7 +40,7 @@ pytest-asyncio = "^1.1.0"
 
 [tool.poetry]
 name = "boosty-downloader"
-version = "2.1.0"
+version = "2.1.1"
 description = "Download any type of content from boosty.to"
 authors = ["Roman Berezkin"]
 readme = "README.md"

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from boosty_downloader.src.application.filtering import DownloadContentTypeFilter
+from boosty_downloader.src.application.mappers.post_mapper import (
+    PostMappingResult,
+    map_post_dto_to_domain,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.base_post_data import (
+        BasePostData,
+    )
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_audio import (
+    BoostyPostDataAudioDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_ok_video import (
+    BoostyOkVideoType,
+    BoostyOkVideoUrl,
+    BoostyPostDataOkVideoDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_text import (
+    BoostyPostDataTextDTO,
+)
+
+
+def _make_post_dto(data: list[BasePostData]) -> PostDTO:
+    return PostDTO(
+        id='test-uuid-1234',
+        title='Test Post',
+        created_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        has_access=True,
+        signed_query='sig=abc',
+        data=data,
+    )
+
+
+def _make_ok_video(
+    *, complete: bool, upload_status: str | None = None
+) -> BoostyPostDataOkVideoDTO:
+    return BoostyPostDataOkVideoDTO(
+        type='ok_video',
+        title='test video',
+        failover_host='https://example.com',
+        duration=timedelta(seconds=120),
+        upload_status=upload_status,
+        complete=complete,
+        player_urls=[
+            BoostyOkVideoUrl(
+                type=BoostyOkVideoType.medium, url='https://example.com/video.mp4'
+            ),
+        ],
+    )
+
+
+def _make_audio(
+    *, complete: bool, upload_status: str | None = None
+) -> BoostyPostDataAudioDTO:
+    return BoostyPostDataAudioDTO(
+        type='audio_file',
+        id='audio-1',
+        url='https://example.com/audio.mp3',
+        title='test audio',
+        size=1024,
+        complete=complete,
+        time_code=0,
+        show_views_counter=False,
+        upload_status=upload_status,
+        views_counter=0,
+    )
+
+
+def test_complete_ok_video_is_mapped():
+    post_dto = _make_post_dto([_make_ok_video(complete=True, upload_status='ok')])
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert isinstance(result, PostMappingResult)
+    assert len(result.post.post_data_chunks) == 1
+    assert not result.incomplete_content_types
+
+
+def test_incomplete_ok_video_is_skipped():
+    post_dto = _make_post_dto([_make_ok_video(complete=False)])
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 0
+    assert DownloadContentTypeFilter.boosty_videos in result.incomplete_content_types
+
+
+def test_incomplete_ok_video_with_null_upload_status():
+    post_dto = _make_post_dto([_make_ok_video(complete=False, upload_status=None)])
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 0
+    assert DownloadContentTypeFilter.boosty_videos in result.incomplete_content_types
+
+
+def test_complete_audio_is_mapped():
+    post_dto = _make_post_dto([_make_audio(complete=True)])
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 1
+    assert not result.incomplete_content_types
+
+
+def test_incomplete_audio_is_skipped():
+    post_dto = _make_post_dto([_make_audio(complete=False)])
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 0
+    assert DownloadContentTypeFilter.audio in result.incomplete_content_types
+
+
+def test_mixed_post_with_incomplete_video_and_complete_text():
+    text_chunk = BoostyPostDataTextDTO(
+        type='text',
+        content='Hello world',
+        modificator='',
+    )
+    post_dto = _make_post_dto(
+        [
+            text_chunk,
+            _make_ok_video(complete=False),
+            _make_audio(complete=True),
+        ]
+    )
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    # Text and audio should be mapped, incomplete video skipped
+    assert len(result.post.post_data_chunks) == 2
+    assert DownloadContentTypeFilter.boosty_videos in result.incomplete_content_types
+    assert DownloadContentTypeFilter.audio not in result.incomplete_content_types


### PR DESCRIPTION
# 📌 Fix incomplete videos downloading issue

## 📝 Description  

When some videos are still in processing by the boosty the uploadingStatus is None, which is crashing the app entirely.
The fix checks that field now and skip unfinished parts and not caches them.

## 🔄 Changelog  

<!-- Please provide a list of general changes made in this PR -->

- **✨ Added:**
	- Tests for the unfinished videos processing
- **🛠 Fixed:** …  
	- The problem with unfinished videos processing 

## 🎯 Related Issue  
<!-- Reference related issues, e.g., Closes #123 -->  
Closes #90 

## ✅ Checklist  

- [x] Locally tested (`make test` and your own judgment)
- [x] Documentation updated (if necessary) 
- [x] Code follows the project's style guidelines (`make lint && make format`)
