### PR TITLE
Handle posts with missing or empty titles gracefully

### DIFF
--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -66,7 +66,7 @@ class DownloadAllPostUseCase:
 
                 # For empty titles use post ID as a fallback (first 8 chars)
                 if len(post_dto.title) == 0:
-                    post_dto.title = f'Not title (id_{post_dto.id[:8]})'
+                    post_dto.title = f'No title (id_{post_dto.id[:8]})'
 
                 post_dto.title = (
                     sanitize_string(post_dto.title).replace('.', '').strip()

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -86,7 +86,11 @@ class DownloadPostByUrlUseCase:
                         f'Found post with UUID: {post_uuid}, starting download...'
                     )
 
-                    post_name = f'{post.created_at.date()} - {post.title}'
+                    post_title = post.title
+                    if len(post_title) == 0:
+                        post_title = f'No title (id_{post.id[:8]})'
+
+                    post_name = f'{post.created_at.date()} - {post_title}'
                     post_name = sanitize_string(post_name).replace('.', '').strip()
 
                     try:

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
@@ -24,6 +24,7 @@ class PostDTO(BoostyBaseDTO):
         if v is None:
             return ''
         return v
+
     created_at: datetime
     updated_at: datetime
     has_access: bool

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003 Pydantic should know this type fully
 
+from pydantic import field_validator
+
 from boosty_downloader.src.infrastructure.boosty_api.models.base import BoostyBaseDTO
 from boosty_downloader.src.infrastructure.boosty_api.models.post.base_post_data import (
     BasePostData,  # noqa: TC001 Pydantic should know this type fully
@@ -15,6 +17,13 @@ class PostDTO(BoostyBaseDTO):
 
     id: str
     title: str
+
+    @field_validator('title', mode='before')
+    @classmethod
+    def none_title_to_empty(cls, v: object) -> object:
+        if v is None:
+            return ''
+        return v
     created_at: datetime
     updated_at: datetime
     has_access: bool


### PR DESCRIPTION
# Fix posts with missing or empty titles causing validation errors

## 📝 Description  

Boosty posts have `null` title in the API response when the title is empty (instead of empty string), which causes Pydantic validation errors when parsing the post data. 

This PR adds defensive handling at two levels:
1. **DTO layer** - a Pydantic `field_validator` converts `None` title to an empty string, preventing validation failures
2. **Use case layer** - both bulk and single-post download now consistently apply a `"No title (id_...)"` fallback for posts with empty titles

## 🔄 Changelog  

- **🛠 Fixed:** Pydantic validation error when API returns `null` for post title
- **🛠 Fixed:** Single-post download creating broken folder names for untitled posts
- **🛠 Fixed:** Typo in fallback title text ("Not title" → "No title")

## 🎯 Related Issue  
Closes #79  

## ✅ Checklist  

- [x] Locally tested (`make test` and your own judgment)
- [x] Documentation updated (if necessary) 
- [x] Code follows the project's style guidelines (`make lint && make format`)