### PR TITLE
Add --cache-dir flag for custom cache database location

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,9 +56,10 @@ jobs:
           fi
         timeout-minutes: 5
 
-      # Enforce that every PR updates the "## Unreleased" section in CHANGELOG.md.
-      # Works by comparing the file list between the PR branch and the base branch -
-      # if CHANGELOG.md isn't in the diff, the check fails.
+      # Enforce that every PR adds new entries to the "## Unreleased" section
+      # in CHANGELOG.md. Simply touching the file is not enough - the check
+      # verifies that the Unreleased section gained new lines compared to the
+      # base branch. Removing the heading or deleting entries won't pass.
       #
       # For non-user-facing PRs (CI fixes, refactoring, docs) this can be skipped:
       #   - Put [skip changelog] anywhere in the PR title, OR
@@ -78,13 +79,51 @@ jobs:
             exit 0
           fi
 
-          if git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -q "^CHANGELOG.md$"; then
-            echo "✅ CHANGELOG.md was updated"
-          else
-            echo "❌ CHANGELOG.md was not updated."
-            echo "Add a line to '## Unreleased' section, or add [skip changelog] to PR title / ci/skip-changelog label."
+          BASE_REF="origin/${{ github.base_ref }}"
+
+          # 1. Verify that ## Unreleased heading still exists
+          if ! grep -q "^## Unreleased" CHANGELOG.md; then
+            echo "::error::Unreleased section is missing from CHANGELOG.md"
+            echo ""
+            echo "❌ '## Unreleased' heading was removed or renamed."
+            echo "Every PR must keep this heading intact and add entries under it."
+            echo "Use [skip changelog] in PR title or ci/skip-changelog label to skip."
             exit 1
           fi
+
+          # 2. Extract the Unreleased section content from base and HEAD
+          BASE_SECTION=$(git show "$BASE_REF:CHANGELOG.md" \
+            | sed -n '/^## Unreleased$/,/^## [0-9]/{/^##/d;p}' 2>/dev/null || echo "")
+          HEAD_SECTION=$(sed -n '/^## Unreleased$/,/^## [0-9]/{/^##/d;p}' CHANGELOG.md)
+
+          # 3. Find lines added to the Unreleased section
+          ADDED=$(diff <(echo "$BASE_SECTION") <(echo "$HEAD_SECTION") \
+            | grep "^> " | sed 's/^> //' | grep -v "^$" || true)
+
+          if [ -z "$ADDED" ]; then
+            echo "::error::No new entries in the Unreleased section of CHANGELOG.md"
+            echo ""
+            echo "❌ No new entries added to '## Unreleased' section."
+            echo ""
+            echo "Add a line describing your changes, for example:"
+            echo "  - Fix the frobnicator timeout when server is slow"
+            echo ""
+            echo "Use [skip changelog] in PR title or ci/skip-changelog label to skip."
+            exit 1
+          fi
+
+          echo "✅ CHANGELOG updated - new entries in Unreleased:"
+          echo ""
+          echo "$ADDED" | while IFS= read -r line; do
+            echo "    $line"
+          done
+
+          # Show new entries in the GitHub Actions job summary
+          {
+            echo "### Changelog"
+            echo ""
+            echo "$ADDED"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build & verify
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,16 +4,17 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
-  push:
-    branches-ignore:
-      - main
 
 jobs:
   check:
     name: 🧪 Lint, Test & Build
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 is needed for the CHANGELOG diff check to find
+      # the merge base between the PR branch and main.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # Speed up repeated CI runs by caching downloaded pip packages.
       # The cache key is derived from poetry.lock, so it invalidates
@@ -77,7 +78,6 @@ jobs:
             exit 0
           fi
 
-          git fetch origin "${{ github.base_ref }}" --depth=1
           if git diff --name-only "origin/${{ github.base_ref }}"...HEAD | grep -q "^CHANGELOG.md$"; then
             echo "✅ CHANGELOG.md was updated"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Add `--cache-dir` flag to store cache database separately from downloads (for network storage setups)
+
 ## 2.1.2
 
 - Fix the empty title bug (the downloading process stopped because of validation error)

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -35,6 +35,7 @@ from boosty_downloader.src.cli.cli_options import (
     # These imports can't be moved to TYPE_CHECKING
     # because they are used by typer at runtime.
     #
+    CacheDirectoryOption,  # noqa: TC001
     CheckTotalCountOption,  # noqa: TC001
     CleanCacheOption,  # noqa: TC001
     ContentTypeFilterOption,  # noqa: TC001
@@ -121,6 +122,7 @@ async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typ
     preferred_video_quality: VideoQualityOption,
     request_delay_seconds: float,
     destination_directory: Path | None,
+    cache_directory: Path | None,
 ) -> None:
     """Download all posts from the specified user"""
     config = init_config()
@@ -131,6 +133,10 @@ async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typ
     # Set the destination directory if provided
     if destination_directory is not None:
         config.downloading_settings.target_directory = destination_directory
+
+    # Set the cache directory if provided
+    if cache_directory is not None:
+        config.downloading_settings.cache_directory = cache_directory
 
     retry_options = ExponentialRetry(
         attempts=5,
@@ -173,6 +179,9 @@ async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typ
         config=AppEnvironment.AppConfig(
             author_name=username,
             target_directory=config.downloading_settings.target_directory.absolute(),
+            cache_directory=config.downloading_settings.cache_directory.absolute()
+            if config.downloading_settings.cache_directory
+            else None,
             boosty_headers=parse_auth_header(auth_header),
             boosty_cookies_jar=parse_session_cookie(cookie_string),
             retry_options=retry_options,
@@ -254,6 +263,7 @@ def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
     check_total_count: CheckTotalCountOption = False,
     clean_cache: CleanCacheOption = False,
     destination_directory: DestinationDirectoryOption = None,
+    cache_directory: CacheDirectoryOption = None,
 ) -> None:
     """
     [bold]ABOUT:[/bold]
@@ -303,6 +313,7 @@ def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
             preferred_video_quality=preferred_video_quality,
             request_delay_seconds=request_delay_seconds,
             destination_directory=destination_directory,
+            cache_directory=cache_directory,
         ),
     )
 

--- a/boosty_downloader/src/application/di/app_environment.py
+++ b/boosty_downloader/src/application/di/app_environment.py
@@ -42,6 +42,7 @@ class AppEnvironment:
         retry_options: RetryOptionsBase
         request_delay_seconds: float
         logger: RichLogger
+        cache_directory: Path | None = None
 
     def __init__(
         self,
@@ -49,6 +50,7 @@ class AppEnvironment:
     ) -> None:
         self.author_name = config.author_name
         self.target_directory = config.target_directory
+        self.cache_directory = config.cache_directory or config.target_directory
         self.boosty_headers = config.boosty_headers
         self.boosty_cookies_jar = config.boosty_cookies_jar
         self.logger = config.logger
@@ -90,7 +92,7 @@ class AppEnvironment:
         )
 
         post_cache = SQLitePostCache(
-            destination=self.target_directory / self.author_name,
+            destination=self.cache_directory / self.author_name,
             logger=self.logger,
         )
         post_cache.__enter__()  # sync context manager

--- a/boosty_downloader/src/cli/cli_options.py
+++ b/boosty_downloader/src/cli/cli_options.py
@@ -101,3 +101,16 @@ DestinationDirectoryOption = Annotated[
         show_default=False,
     ),
 ]
+
+CacheDirectoryOption = Annotated[
+    Path | None,
+    typer.Option(
+        '--cache-dir',
+        help='Custom directory for cache database (useful when downloading to network storage)',
+        dir_okay=True,
+        file_okay=False,
+        resolve_path=True,
+        rich_help_panel=HelpPanels.actions,
+        show_default=False,
+    ),
+]

--- a/boosty_downloader/src/cli/cli_options.py
+++ b/boosty_downloader/src/cli/cli_options.py
@@ -106,7 +106,7 @@ CacheDirectoryOption = Annotated[
     Path | None,
     typer.Option(
         '--cache-dir',
-        help='Custom directory for cache database (useful when downloading to network storage)',
+        help='Custom directory for cache database (useful when downloading to network storage), cache dir will have subdirectory for each author',
         dir_okay=True,
         file_okay=False,
         resolve_path=True,

--- a/boosty_downloader/src/infrastructure/yaml_configuration/config.py
+++ b/boosty_downloader/src/infrastructure/yaml_configuration/config.py
@@ -23,6 +23,7 @@ class DownloadSettings(BaseModel):
     """Settings for the script downloading process"""
 
     target_directory: Path = Path('./boosty-downloads')
+    cache_directory: Path | None = None
 
 
 class AuthSettings(BaseModel):


### PR DESCRIPTION
## 📝 Summary

Add `--cache-dir` CLI flag and `cache_directory` config.yaml option to store the SQLite cache database separately from downloads.

SQLite requires OS-level file locking which doesn't work reliably on network filesystems (CIFS/SMB). Users downloading to NAS get `database is locked` errors even with a single process. This flag allows placing the cache on a local disk while keeping downloads on network storage.

When not specified, cache stays next to downloads as before - no behavior change for existing users.

Also fixes CI: full git clone for changelog diff check and removes duplicate push trigger.

## 🎯 Related Issue

Closes #95

## ✅ Checklist

- [x] Locally tested (`make test`)
- [x] CI checks pass (`make ci-check`)
- [x] Added a line to `## Unreleased` section in CHANGELOG.md describing the change (or added `ci/skip-changelog` label if not user-facing)