### PR TITLE
Auth helper and UX/UI restructure (subcommands instead of flags)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,15 +66,16 @@ jobs:
       #   - Add the "ci/skip-changelog" label to the PR
       - name: Check CHANGELOG.md updated
         if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
           if echo "$PR_TITLE" | grep -qi "\[skip changelog\]"; then
             echo "⏭️ Skipping changelog check (title marker)"
             exit 0
           fi
 
-          LABELS="${{ join(github.event.pull_request.labels.*.name, ',') }}"
-          if echo "$LABELS" | grep -qi "ci/skip-changelog"; then
+          if echo "$PR_LABELS" | grep -qi "ci/skip-changelog"; then
             echo "⏭️ Skipping changelog check (label)"
             exit 0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- MAJOR: New way of calling commands (use subcommands for different scenario)
+- Add `show-auth-script` subcommand for extracting auth credentials via browser console
+
 ## 2.2.0
 
 - Add `--cache-dir` flag to store cache database separately from downloads (for network storage setups)

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ help:
 	@echo ''
 	@echo '  📦 Building:'
 	@echo '    make build           build wheel and source distribution'
+	@echo '    make build-install   build and install locally for testing'
 	@echo ''
 	@echo '  🏷️  Release:'
 	@echo '    make release v=patch   auto-bump patch (2.1.2 -> 2.1.3)'
@@ -49,6 +50,9 @@ deps:
 build:
 	poetry build --no-cache
 	@echo Build complete at /dist/
+
+build-install:
+	@python scripts/build_install.py
 
 # ------------------------------------------------------------------------------
 # 🩺 Code Health Checks

--- a/README.md
+++ b/README.md
@@ -83,12 +83,21 @@ The post content itself is saved in html with a little bit of styling.
 
 ### Step 1: Get the auth cookie and auth header
 
+#### Option 1 - Manually
+
 1. Open the [Boosty](https://boosty.to) website.
 2. Click the "Sign in" button and fill you credentials.
 3. Navigate to any author you have access to and scroll post a little.
 4. Copy auth token and cookie from browser network tab.
 
 <img src="https://raw.githubusercontent.com/Glitchy-Sheep/boosty-downloader/main/assets/auth_guide.png">
+
+#### Option 2 - With helper script
+
+1. Run `boosty-downloader show-auth-script` to show the helper script (it will be copied to your clipboard automatically).
+2. Open the [Boosty](https://boosty.to) website and log in.
+3. Open browser console (F12) and paste the script.
+4. Scroll the page a little - a floating box with your credentials will appear.
 
 ### Step 2: Paste the cookie and auth header into the config file
 
@@ -101,7 +110,7 @@ This config will be created during first run of the app in the current working d
 Now you can just download your content with the following command:
 
 ```bash
-boosty-downloader --username YOUR_CREATOR_NAME
+boosty-downloader download --username YOUR_CREATOR_NAME
 ```
 
 ## 💖 Contributing

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ The post content itself is saved in html with a little bit of styling.
   - [🛠️ Installation](#️-installation)
   - [🚀 Configuration for Usage](#-configuration-for-usage)
     - [Step 1: Get the auth cookie and auth header](#step-1-get-the-auth-cookie-and-auth-header)
+      - [Option 1 - Manually](#option-1---manually)
+      - [Option 2 - With helper script](#option-2---with-helper-script)
     - [Step 2: Paste the cookie and auth header into the config file](#step-2-paste-the-cookie-and-auth-header-into-the-config-file)
     - [Step 3: Run the utility](#step-3-run-the-utility)
   - [💖 Contributing](#-contributing)
@@ -35,13 +37,14 @@ The post content itself is saved in html with a little bit of styling.
 
 - 📦 **Bulk download**: Download all available content from your favorite creator.
 - 🔎 **Total checker**: See how many posts are available to you, and which are not.
-- 📂 **Content type filters**: Download only the content you need (videos, images, etc), choose what you really want with flags (see below).
+- 📂 **Content type filters**: Download only the content you need (videos, images, etc) with `--content-type-filter`.
 - 📄 **Download specific posts**: Download post by url and username.
 - 🔃 **Sync content seamlessly**: The utility keeps cache of already downloaded posts, so you can resume your download at any time or get new content after a while.
 - 📼 **Choose your video quality**: You can choose preferred video quality to download (for boosty videos)
 - 🎨 **Beauty posts preview**: You can see posts content with rendered offline html files with dark/light theme changing.
 - 📊 **Order matters**: Posts have dates in names, so you can just sort it by name in your file explorer and see them in the correct chronological order.
 - 🆙 **App update checker**: If new updates are available, you'll be notified when you use the application next time.
+- 🔑 **Auth helper script**: Run `boosty-downloader show-auth-script` to get a browser console script that extracts your credentials automatically.
 
 
 ## 📸 Screenshots & Usage

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -252,7 +252,9 @@ async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typ
 
 
 # Use wrapper because typer can't run async functions directly
-@typer_app.command()
+@typer_app.command(
+    'download', short_help='Download posts from a Boosty creator.', no_args_is_help=True
+)
 def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
     *,
     username: UsernameOption,
@@ -266,10 +268,9 @@ def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
     cache_directory: CacheDirectoryOption = None,
 ) -> None:
     """
-    [bold]ABOUT:[/bold]
+    Download posts from a Boosty creator.
 
-    ======
-        CLI tool to download Boosty posts by author username.
+    [bold]DETAILS:[/bold]
 
         - Use `--post-url` to download a specific post.
         - By default, downloads all posts from newest to oldest with all available contents.
@@ -279,7 +280,7 @@ def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
     [bold]CONTENT FILTERING:[/bold]
 
         - Use multiple `-f` flags to select content types (all included by default).
-        - Example: [italic]boosty-downloader --username <USERNAME> -f files -f post_content[/italic]
+        - Example: [italic]boosty-downloader download --username <USERNAME> -f files -f post_content[/italic]
         - [bold red]NOTE:[/bold red] If you specify [italic]post_content[/italic] without [italic]boosty_videos[/italic] or [italic]external_videos[/italic],
                 videos won't attach to post previews due to cache limitations.
         - For best results, just leave all filters by default.
@@ -316,6 +317,16 @@ def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
             cache_directory=cache_directory,
         ),
     )
+
+
+@typer_app.command('show-auth-script')
+def show_auth_script_entrypoint() -> None:
+    """Show a JS helper script to extract Boosty credentials from browser console."""
+    from boosty_downloader.src.cli.boosty_token_viewer import (  # noqa: PLC0415
+        show_js_helper_script,
+    )
+
+    show_js_helper_script()
 
 
 def entry_point() -> None:

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -1,49 +1,19 @@
-"""Main entrypoint of the app"""
+"""Main entrypoint of the app."""
 
 from __future__ import annotations
 
-import asyncio
-import importlib.metadata
-from typing import TYPE_CHECKING
-
-import aiohttp
 import typer
 from aiohttp.client_exceptions import ClientConnectorDNSError
-from aiohttp_retry import ExponentialRetry
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
 
-from boosty_downloader.src.application.di.app_environment import AppEnvironment
-from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.exceptions.application_errors import (
     ApplicationCancelledError,
 )
-from boosty_downloader.src.application.filtering import (
-    DownloadContentTypeFilter,
-    VideoQualityOption,
-)
-from boosty_downloader.src.application.use_cases.check_total_posts import (
-    ReportTotalPostsCountUseCase,
-)
-from boosty_downloader.src.application.use_cases.download_all_posts import (
-    DownloadAllPostUseCase,
-)
-from boosty_downloader.src.application.use_cases.download_specific_post import (
-    DownloadPostByUrlUseCase,
-)
-from boosty_downloader.src.cli.cli_options import (
-    # ---------------------------------------------------------------------------
-    # These imports can't be moved to TYPE_CHECKING
-    # because they are used by typer at runtime.
-    #
-    CacheDirectoryOption,  # noqa: TC001
-    CheckTotalCountOption,  # noqa: TC001
-    CleanCacheOption,  # noqa: TC001
-    ContentTypeFilterOption,  # noqa: TC001
-    DestinationDirectoryOption,  # noqa: TC001
-    PostUrlOption,  # noqa: TC001
-    PreferredVideoQualityOption,  # noqa: TC001
-    RequestDelaySecondsOption,  # noqa: TC001
-    UsernameOption,  # noqa: TC001
+from boosty_downloader.src.cli.commands import (
+    check,
+    clean_cache,
+    download,
+    show_auth_script,
 )
 from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPINoUsernameError,
@@ -51,293 +21,38 @@ from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIUnknownError,
     BoostyAPIValidationError,
 )
-from boosty_downloader.src.infrastructure.boosty_api.utils.auth_parsers import (
-    parse_auth_header,
-    parse_session_cookie,
-)
-from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
-    ExternalVideosDownloader,
-)
 from boosty_downloader.src.infrastructure.loggers import logger_instances
-from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import (
-    FailedDownloadsLogger,
-)
-from boosty_downloader.src.infrastructure.update_checker.pypi_checker import (
-    CheckFailed,
-    NoUpdate,
-    UpdateAvailable,
-    check_for_updates,
-)
-from boosty_downloader.src.infrastructure.yaml_configuration.config import init_config
-
-if TYPE_CHECKING:
-    from pathlib import Path
-
-    from boosty_downloader.src.cli.console_progress_reporter import (
-        ProgressReporter,
-    )
 
 typer_app = typer.Typer(
-    no_args_is_help=True,
     add_completion=False,
     rich_markup_mode='rich',
+    invoke_without_command=True,
 )
 
 GITHUB_ISSUES_URL = 'https://github.com/Glitchy-Sheep/boosty-downloader/issues'
 
 
-def show_start_summary(
-    pr: ProgressReporter,
-    destination_directory: Path,
-    content_type_filter: list[DownloadContentTypeFilter],
-) -> None:
-    """Just simple review before start downloading"""
-    pr.info(
-        f'[italic]Destination directory[/italic]: [bold green]{destination_directory}[/bold green]'
-    )
-    pr.info(
-        '----------------------------------------------------------------------------------\n'
-        'Script will download: [bold green]'
-        + ', '.join(str(item.name) for item in content_type_filter)
-        + '[/bold green]\n'
-        '----------------------------------------------------------------------------------\n'
-    )
-    pr.notice(
-        'You can safely interrupt the download at any time with [bold yellow]Ctrl+C[/bold yellow].\n'
-    )
-    if DownloadContentTypeFilter.external_videos in content_type_filter:
-        pr.notice(
-            'Progress bar for external videos downloadings can be glitchy, because yt-dlp downloads them by chunks.\n'
-            "If you see strange progress movement that's normal in most cases, just be patient.\n"
-        )
-
-
-async def typer_cmd_handler(  # noqa: PLR0913 (too many arguments because of typer)
-    *,
-    username: str,
-    post_url: PostUrlOption | None,
-    check_total_count: bool,
-    clean_cache: bool,
-    content_type_filter: list[DownloadContentTypeFilter],
-    preferred_video_quality: VideoQualityOption,
-    request_delay_seconds: float,
-    destination_directory: Path | None,
-    cache_directory: Path | None,
-) -> None:
-    """Download all posts from the specified user"""
-    config = init_config()
-
-    cookie_string = config.auth.cookie
-    auth_header = config.auth.auth_header
-
-    # Set the destination directory if provided
-    if destination_directory is not None:
-        config.downloading_settings.target_directory = destination_directory
-
-    # Set the cache directory if provided
-    if cache_directory is not None:
-        config.downloading_settings.cache_directory = cache_directory
-
-    retry_options = ExponentialRetry(
-        attempts=5,
-        exceptions={
-            aiohttp.ClientConnectorError,
-            aiohttp.ClientOSError,
-            aiohttp.ServerDisconnectedError,
-            aiohttp.ClientResponseError,
-            aiohttp.ClientConnectionError,
-        },
-    )
-
-    # --------------------------------------------------------------------------
-    # Check for updates and notify the user
-    current_version = importlib.metadata.version('boosty-downloader')
-    result = check_for_updates(current_version, 'boosty-downloader')
-    match result:
-        case UpdateAvailable():
-            logger_instances.downloader_logger.warning(
-                f'🔔 [bold green]Update available[/bold green]: {result.latest_version} (current: {result.current_version})'
-            )
-            logger_instances.downloader_logger.warning(
-                'You can update with --> [bold]pip install -U boosty-downloader[/bold]'
-            )
-            logger_instances.downloader_logger.warning(
-                'But first, please check the changelog for breaking changes\n'
-            )
-        case NoUpdate():
-            logger_instances.downloader_logger.info(
-                'You are using the latest boosty-downloader version.\n'
-            )
-        case CheckFailed():
-            logger_instances.downloader_logger.error(
-                'Failed to check for updates, please check it manually.\n'
-            )
-
-    # --------------------------------------------------------------------------
-    # Prepare app environment and start the task
-    async with AppEnvironment(
-        config=AppEnvironment.AppConfig(
-            author_name=username,
-            target_directory=config.downloading_settings.target_directory.absolute(),
-            cache_directory=config.downloading_settings.cache_directory.absolute()
-            if config.downloading_settings.cache_directory
-            else None,
-            boosty_headers=parse_auth_header(auth_header),
-            boosty_cookies_jar=parse_session_cookie(cookie_string),
-            retry_options=retry_options,
-            request_delay_seconds=request_delay_seconds,
-            logger=logger_instances.downloader_logger,
-        )
-    ) as app_environment:
-        downloading_context = DownloadContext(
-            author_name=username,
-            downloader_session=app_environment.downloading_retry_client,
-            external_videos_downloader=ExternalVideosDownloader(),
-            filters=content_type_filter,
-            post_cache=app_environment.post_cache,
-            preferred_video_quality=preferred_video_quality.to_ok_video_type(),
-            progress_reporter=app_environment.progress_reporter,
-            failed_logger=FailedDownloadsLogger(
-                log_file_path=config.downloading_settings.target_directory
-                / username
-                / 'failed_downloads.log',
-            ),
-        )
-
-        # ------------------------------------------------------------------
-        # Cache cleaning
-        if clean_cache:
-            app_environment.post_cache.remove_cache_completely()
-            logger_instances.downloader_logger.success(
-                f'Cache for {username} has been cleaned successfully'
-            )
-            return
-
-        # ------------------------------------------------------------------
-        # Total Checker
-        if check_total_count:
-            await ReportTotalPostsCountUseCase(
-                author_name=username,
-                logger=logger_instances.downloader_logger,
-                boosty_api=app_environment.boosty_api_client,
-            ).execute()
-            return
-
-        # ------------------------------------------------------------------
-        # Download specific post by URL
-        if post_url is not None:
-            await DownloadPostByUrlUseCase(
-                post_url=post_url,
-                boosty_api=app_environment.boosty_api_client,
-                destination=app_environment.destination_directory,
-                download_context=downloading_context,
-            ).execute()
-            return
-
-        # ------------------------------------------------------------------
-        # Download all posts
-
-        show_start_summary(
-            pr=app_environment.progress_reporter,
-            destination_directory=app_environment.destination_directory,
-            content_type_filter=content_type_filter,
-        )
-
-        await DownloadAllPostUseCase(
-            author_name=username,
-            boosty_api=app_environment.boosty_api_client,
-            destination=app_environment.destination_directory,
-            download_context=downloading_context,
-        ).execute()
-
-
-# Use wrapper because typer can't run async functions directly
-@typer_app.command(
-    'download', short_help='Download posts from a Boosty creator.', no_args_is_help=True
-)
-def typer_cmd_entrypoint(  # noqa: PLR0913 (too many arguments because of typer)
-    *,
-    username: UsernameOption,
-    request_delay_seconds: RequestDelaySecondsOption = 2.5,
-    post_url: PostUrlOption = None,
-    content_type_filter: ContentTypeFilterOption = None,
-    preferred_video_quality: PreferredVideoQualityOption = VideoQualityOption.medium,
-    check_total_count: CheckTotalCountOption = False,
-    clean_cache: CleanCacheOption = False,
-    destination_directory: DestinationDirectoryOption = None,
-    cache_directory: CacheDirectoryOption = None,
-) -> None:
+@typer_app.callback()
+def _app_callback(ctx: typer.Context) -> None:  # pyright: ignore[reportUnusedFunction]
     """
-    Download posts from a Boosty creator.
+    CLI tool to download Boosty posts by author username.
 
-    [bold]DETAILS:[/bold]
-
-        - Use `--post-url` to download a specific post.
-        - By default, downloads all posts from newest to oldest with all available contents.
-        - Unavailable posts are skipped, and you will be notified about them.
-
-
-    [bold]CONTENT FILTERING:[/bold]
-
-        - Use multiple `-f` flags to select content types (all included by default).
-        - Example: [italic]boosty-downloader download --username <USERNAME> -f files -f post_content[/italic]
-        - [bold red]NOTE:[/bold red] If you specify [italic]post_content[/italic] without [italic]boosty_videos[/italic] or [italic]external_videos[/italic],
-                videos won't attach to post previews due to cache limitations.
-        - For best results, just leave all filters by default.
-
-
-    [bold]RATE LIMITING:[/bold]
-
-        - Increase request delay (default 2.5s) if you get errors.
-        - Please avoid spamming the API.
-
-
-    [bold]ABOUT CONTENT SYNC & CACHING:[/bold]
-
-        - Downloaded content is cached automatically to avoid duplicates.
-        - Downloading the same post with different filters downloads only missing parts.
-        - Posts updated by creators are fully re-downloaded.
-        - Cache doesn't check local files, you can delete them and they still won't re-download.
-
+    Run [bold]boosty-downloader COMMAND --help[/bold] to see details about a specific command.
     """
-    asyncio.run(
-        typer_cmd_handler(
-            username=username,
-            check_total_count=check_total_count,
-            clean_cache=clean_cache,
-            post_url=post_url,
-            content_type_filter=(
-                content_type_filter
-                if content_type_filter
-                else list(DownloadContentTypeFilter)
-            ),
-            preferred_video_quality=preferred_video_quality,
-            request_delay_seconds=request_delay_seconds,
-            destination_directory=destination_directory,
-            cache_directory=cache_directory,
-        ),
-    )
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
+        raise typer.Exit
 
 
-@typer_app.command('show-auth-script')
-def show_auth_script_entrypoint() -> None:
-    """Show a JS helper script to extract Boosty credentials from browser console."""
-    from boosty_downloader.src.cli.boosty_token_viewer import (  # noqa: PLC0415
-        show_js_helper_script,
-    )
-
-    show_js_helper_script()
+# Register all CLI commands
+download.register(typer_app)
+check.register(typer_app)
+clean_cache.register(typer_app)
+show_auth_script.register(typer_app)
 
 
 def entry_point() -> None:
-    """
-    Run main entry point of the whole app.
-
-    This run typer CLI using app() config.
-
-    It doesn't run the app directly, but through main_wrapper,
-    because main app by itself is async and can't be run directly with typer.
-    """
+    """Run the CLI app with top-level error handling."""
     try:
         typer_app()
     except BoostyAPINoUsernameError:
@@ -375,7 +90,7 @@ def entry_point() -> None:
             'Cache format may be outdated after application update.'
         )
         logger_instances.downloader_logger.info(
-            '👉 You can clean outdated cache with --clean-cache flag'
+            '👉 You can clean outdated cache with the [bold]clean-cache[/bold] command'
         )
         logger_instances.downloader_logger.info(
             '👉 If this will still happen - please report it at GitHub issues:'

--- a/boosty_downloader/src/application/di/app_environment.py
+++ b/boosty_downloader/src/application/di/app_environment.py
@@ -1,4 +1,4 @@
-"""Defines the application environment and dependency injection context for resource management."""
+"""Manages the application's resource initialization and cleanup, providing an async context for dependency injection."""
 
 from contextlib import AsyncExitStack
 from dataclasses import dataclass

--- a/boosty_downloader/src/application/di/initialized_app.py
+++ b/boosty_downloader/src/application/di/initialized_app.py
@@ -1,0 +1,100 @@
+"""Application initialization: config loading, update check, and AppEnvironment setup."""
+
+from __future__ import annotations
+
+import importlib.metadata
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aiohttp_retry import ExponentialRetry
+
+from boosty_downloader.src.application.di.app_environment import AppEnvironment
+from boosty_downloader.src.infrastructure.boosty_api.utils.auth_parsers import (
+    parse_auth_header,
+    parse_session_cookie,
+)
+from boosty_downloader.src.infrastructure.loggers import logger_instances
+from boosty_downloader.src.infrastructure.update_checker.pypi_checker import (
+    CheckFailed,
+    NoUpdate,
+    UpdateAvailable,
+    check_for_updates,
+)
+from boosty_downloader.src.infrastructure.yaml_configuration.config import init_config
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+def _check_and_log_updates() -> None:
+    """Check PyPI for updates and log the result."""
+    current_version = importlib.metadata.version('boosty-downloader')
+    result = check_for_updates(current_version, 'boosty-downloader')
+    match result:
+        case UpdateAvailable():
+            logger_instances.downloader_logger.warning(
+                f'🔔 [bold green]Update available[/bold green]: {result.latest_version} (current: {result.current_version})'
+            )
+            logger_instances.downloader_logger.warning(
+                'You can update with --> [bold]pip install -U boosty-downloader[/bold]'
+            )
+            logger_instances.downloader_logger.warning(
+                'But first, please check the changelog for breaking changes\n'
+            )
+        case NoUpdate():
+            logger_instances.downloader_logger.info(
+                'You are using the latest boosty-downloader version.\n'
+            )
+        case CheckFailed():
+            logger_instances.downloader_logger.error(
+                'Failed to check for updates, please check it manually.\n'
+            )
+
+
+@asynccontextmanager
+async def initialized_app(
+    *,
+    username: str,
+    request_delay_seconds: float,
+    destination_directory: Path | None = None,
+    cache_directory: Path | None = None,
+) -> AsyncIterator[AppEnvironment.Environment]:
+    """Load config, check for updates, and yield an initialized AppEnvironment."""
+    config = init_config()
+
+    if destination_directory is not None:
+        config.downloading_settings.target_directory = destination_directory
+
+    if cache_directory is not None:
+        config.downloading_settings.cache_directory = cache_directory
+
+    retry_options = ExponentialRetry(
+        attempts=5,
+        exceptions={
+            aiohttp.ClientConnectorError,
+            aiohttp.ClientOSError,
+            aiohttp.ServerDisconnectedError,
+            aiohttp.ClientResponseError,
+            aiohttp.ClientConnectionError,
+        },
+    )
+
+    _check_and_log_updates()
+
+    async with AppEnvironment(
+        config=AppEnvironment.AppConfig(
+            author_name=username,
+            target_directory=config.downloading_settings.target_directory.absolute(),
+            cache_directory=config.downloading_settings.cache_directory.absolute()
+            if config.downloading_settings.cache_directory
+            else None,
+            boosty_headers=parse_auth_header(config.auth.auth_header),
+            boosty_cookies_jar=parse_session_cookie(config.auth.cookie),
+            retry_options=retry_options,
+            request_delay_seconds=request_delay_seconds,
+            logger=logger_instances.downloader_logger,
+        )
+    ) as app_env:
+        yield app_env

--- a/boosty_downloader/src/cli/boosty_token_viewer.py
+++ b/boosty_downloader/src/cli/boosty_token_viewer.py
@@ -1,0 +1,144 @@
+"""Helper script for extracting Boosty credentials via browser console."""
+
+from __future__ import annotations
+
+import rich
+from rich.syntax import Syntax
+
+_JS_HELPER_SCRIPT = """\
+(function() {
+    let monitoring = true;
+
+    // --- Extract auth token from the "auth" cookie ---
+    // Boosty stores a JSON object in the "auth" cookie with an accessToken field.
+    const getToken = () => {
+        const raw = document.cookie.split("; ")
+            .find(c => c.startsWith("auth="))
+            ?.split("=").slice(1).join("=");  // .slice(1) handles '=' inside the value
+        if (!raw) return null;
+        try { return JSON.parse(decodeURIComponent(raw)).accessToken || null; }
+        catch { return null; }
+    };
+
+    // --- Build the floating credentials box ---
+    // Creates the box with buttons only once. Returns existing box on subsequent calls,
+    // so buttons are never destroyed and stay clickable.
+    const createBox = () => {
+        const existing = document.getElementById("boosty-creds-box");
+        if (existing) return existing;
+
+        const box = document.createElement("div");
+        box.id = "boosty-creds-box";
+        box.style.cssText = `
+            position:fixed; top:20px; right:20px; width:420px; max-height:80vh;
+            background:#fff; border:1px solid #ccc; border-radius:8px;
+            z-index:99999; font:14px sans-serif; color:#333;
+            box-shadow:0 4px 12px rgba(0,0,0,.25); overflow-y:auto;
+        `;
+
+        // --- Toolbar with copy/close buttons ---
+        const btnStyle = "padding:4px 8px; font-size:12px; cursor:pointer";
+        const makeBtn = (label, onClick) => {
+            const b = document.createElement("button");
+            b.textContent = label;
+            b.style.cssText = btnStyle;
+            b.onclick = onClick;
+            return b;
+        };
+
+        const toolbar = document.createElement("div");
+        toolbar.style.cssText = "display:flex; gap:5px; padding:8px; border-bottom:1px solid #ccc; background:#f7f7f7";
+        toolbar.append(
+            makeBtn("Copy Token", () =>
+                navigator.clipboard.writeText(document.getElementById("cred-token")?.textContent || "")),
+            makeBtn("Copy Cookie", () =>
+                navigator.clipboard.writeText(document.getElementById("cred-cookie")?.textContent || "")),
+            makeBtn("Close and Stop Monitoring", () => { monitoring = false; box.remove(); }),
+        );
+
+        const content = document.createElement("div");
+        content.id = "boosty-creds-content";
+        content.style.padding = "12px";
+
+        box.append(toolbar, content);
+        document.body.appendChild(box);
+        return box;
+    };
+
+    // --- Fill credentials into the box ---
+    // Only the content area is updated, buttons in toolbar are untouched.
+    const showCredentials = (token, cookies) => {
+        createBox();
+        const codeStyle = "display:block; background:#f5f5f5; padding:8px; border-radius:4px; white-space:pre-wrap; word-break:break-all;";
+        document.getElementById("boosty-creds-content").innerHTML = `
+            <h4 style="margin:6px 0">Access Token</h4>
+            <code id="cred-token" style="${codeStyle}">Bearer ${token}</code>
+            <h4 style="margin:12px 0 6px">Cookies</h4>
+            <code id="cred-cookie" style="${codeStyle}">${cookies}</code>
+        `;
+    };
+
+    // --- Hook into fetch() and XMLHttpRequest ---
+    // On every network request, check if credentials are available and show them.
+    const check = () => {
+        if (!monitoring) return;
+        const token = getToken();
+        if (token) showCredentials(token, document.cookie);
+    };
+
+    const origFetch = window.fetch;
+    window.fetch = async (...args) => { check(); return origFetch.apply(this, args); };
+
+    const origOpen = XMLHttpRequest.prototype.open;
+    XMLHttpRequest.prototype.open = function(...args) { check(); return origOpen.apply(this, args); };
+
+    console.log("Boosty credential monitor started. Scroll the page to trigger detection.");
+})();
+"""
+
+
+def _try_copy_to_clipboard(text: str) -> bool:
+    """Try to copy text to clipboard. Return True on success."""
+    try:
+        import pyperclip  # noqa: PLC0415
+
+        pyperclip.copy(text)
+    except Exception:  # noqa: BLE001
+        return False
+    else:
+        return True
+
+
+def show_js_helper_script() -> None:
+    """Show the JS helper script and try to copy it to clipboard."""
+    rich.print(
+        Syntax(
+            _JS_HELPER_SCRIPT,
+            'javascript',
+            theme='dracula',
+            word_wrap=False,
+            background_color='#000000',
+            tab_size=2,
+        )
+    )
+
+    copied = _try_copy_to_clipboard(_JS_HELPER_SCRIPT)
+
+    rich.print()
+    if copied:
+        rich.print(
+            '[bold green]The script has been copied to your clipboard.[/bold green]'
+        )
+    else:
+        rich.print(
+            '[bold yellow]Could not copy to clipboard. Please copy the script manually.[/bold yellow]'
+        )
+
+    rich.print()
+    rich.print('1. Open [link=https://boosty.to]boosty.to[/link] and log in.')
+    rich.print('2. Paste the script into the browser console (F12).')
+    rich.print('3. Scroll the page to trigger a network request.')
+    rich.print('4. A floating box with your credentials will appear.')
+    rich.print(
+        '5. Click [bold]Close and Stop Monitoring[/bold] or refresh the page when done.'
+    )

--- a/boosty_downloader/src/cli/cli_options.py
+++ b/boosty_downloader/src/cli/cli_options.py
@@ -68,26 +68,6 @@ PostUrlOption = Annotated[
     ),
 ]
 
-CheckTotalCountOption = Annotated[
-    bool,
-    typer.Option(
-        '--only-check-total',
-        '-t',
-        help='Check total count of accessible/inaccessible(+names) posts and exit, no download',
-        rich_help_panel=HelpPanels.actions,
-    ),
-]
-
-CleanCacheOption = Annotated[
-    bool,
-    typer.Option(
-        '--clean-cache',
-        '-c',
-        help='Remove posts cache for selected username [italic]completely[/italic], use with caution',
-        rich_help_panel=HelpPanels.actions,
-    ),
-]
-
 DestinationDirectoryOption = Annotated[
     Path | None,
     typer.Option(

--- a/boosty_downloader/src/cli/commands/check.py
+++ b/boosty_downloader/src/cli/commands/check.py
@@ -1,0 +1,69 @@
+"""CLI command: check total accessible/inaccessible posts count."""
+
+# pyright: reportUnusedFunction=false
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from boosty_downloader.src.application.di.initialized_app import initialized_app
+from boosty_downloader.src.application.use_cases.check_total_posts import (
+    ReportTotalPostsCountUseCase,
+)
+from boosty_downloader.src.cli.cli_options import (
+    CacheDirectoryOption,  # noqa: TC001
+    DestinationDirectoryOption,  # noqa: TC001
+    RequestDelaySecondsOption,  # noqa: TC001
+    UsernameOption,  # noqa: TC001
+)
+from boosty_downloader.src.infrastructure.loggers import logger_instances
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import typer
+
+
+async def _check_handler(
+    *,
+    username: str,
+    request_delay_seconds: float,
+    destination_directory: Path | None,
+    cache_directory: Path | None,
+) -> None:
+    async with initialized_app(
+        username=username,
+        request_delay_seconds=request_delay_seconds,
+        destination_directory=destination_directory,
+        cache_directory=cache_directory,
+    ) as app_env:
+        await ReportTotalPostsCountUseCase(
+            author_name=username,
+            logger=logger_instances.downloader_logger,
+            boosty_api=app_env.boosty_api_client,
+        ).execute()
+
+
+def register(app: typer.Typer) -> None:
+    """Register the check command."""
+
+    @app.command(
+        'check',
+        short_help='See how many posts of some creator are accessible to you and which are not.',
+    )
+    def check_entrypoint(
+        *,
+        username: UsernameOption,
+        request_delay_seconds: RequestDelaySecondsOption = 2.5,
+        destination_directory: DestinationDirectoryOption = None,
+        cache_directory: CacheDirectoryOption = None,
+    ) -> None:
+        """Check total count of accessible/inaccessible posts and exit without downloading."""
+        asyncio.run(
+            _check_handler(
+                username=username,
+                request_delay_seconds=request_delay_seconds,
+                destination_directory=destination_directory,
+                cache_directory=cache_directory,
+            ),
+        )

--- a/boosty_downloader/src/cli/commands/clean_cache.py
+++ b/boosty_downloader/src/cli/commands/clean_cache.py
@@ -1,0 +1,64 @@
+"""CLI command: clean download cache for a user."""
+
+# pyright: reportUnusedFunction=false
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from boosty_downloader.src.cli.cli_options import (
+    CacheDirectoryOption,  # noqa: TC001
+    UsernameOption,  # noqa: TC001
+)
+from boosty_downloader.src.infrastructure.loggers import logger_instances
+from boosty_downloader.src.infrastructure.post_caching.post_cache import SQLitePostCache
+from boosty_downloader.src.infrastructure.yaml_configuration.config import init_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import typer
+
+
+def _clean_cache(
+    *,
+    username: str,
+    cache_directory: Path | None,
+) -> None:
+    config = init_config()
+
+    if cache_directory is not None:
+        config.downloading_settings.cache_directory = cache_directory
+
+    cache_dir = (
+        config.downloading_settings.cache_directory
+        or config.downloading_settings.target_directory
+    )
+
+    with SQLitePostCache(
+        destination=cache_dir.absolute() / username,
+        logger=logger_instances.downloader_logger,
+    ) as post_cache:
+        post_cache.remove_cache_completely()
+
+    logger_instances.downloader_logger.success(
+        f'Cache for {username} has been cleaned successfully'
+    )
+
+
+def register(app: typer.Typer) -> None:
+    """Register the clean-cache command."""
+
+    @app.command(
+        'clean-cache',
+        short_help='Remove cached post data for a creator.',
+    )
+    def clean_cache_entrypoint(
+        *,
+        username: UsernameOption,
+        cache_directory: CacheDirectoryOption = None,
+    ) -> None:
+        """Remove the posts cache for the selected username completely."""
+        _clean_cache(
+            username=username,
+            cache_directory=cache_directory,
+        )

--- a/boosty_downloader/src/cli/commands/download.py
+++ b/boosty_downloader/src/cli/commands/download.py
@@ -1,0 +1,189 @@
+"""CLI command: download posts from a Boosty creator."""
+
+# pyright: reportUnusedFunction=false
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.di.initialized_app import initialized_app
+from boosty_downloader.src.application.filtering import (
+    DownloadContentTypeFilter,
+    VideoQualityOption,
+)
+from boosty_downloader.src.application.use_cases.download_all_posts import (
+    DownloadAllPostUseCase,
+)
+from boosty_downloader.src.application.use_cases.download_specific_post import (
+    DownloadPostByUrlUseCase,
+)
+from boosty_downloader.src.cli.cli_options import (
+    CacheDirectoryOption,  # noqa: TC001
+    ContentTypeFilterOption,  # noqa: TC001
+    DestinationDirectoryOption,  # noqa: TC001
+    PostUrlOption,  # noqa: TC001
+    PreferredVideoQualityOption,  # noqa: TC001
+    RequestDelaySecondsOption,  # noqa: TC001
+    UsernameOption,  # noqa: TC001
+)
+from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+    ExternalVideosDownloader,
+)
+from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import (
+    FailedDownloadsLogger,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import typer
+
+    from boosty_downloader.src.cli.console_progress_reporter import (
+        ProgressReporter,
+    )
+
+
+def _show_start_summary(
+    pr: ProgressReporter,
+    destination_directory: Path,
+    content_type_filter: list[DownloadContentTypeFilter],
+) -> None:
+    """Display a summary before starting the download."""
+    pr.info(
+        f'[italic]Destination directory[/italic]: [bold green]{destination_directory}[/bold green]'
+    )
+    pr.info(
+        '----------------------------------------------------------------------------------\n'
+        'Script will download: [bold green]'
+        + ', '.join(str(item.name) for item in content_type_filter)
+        + '[/bold green]\n'
+        '----------------------------------------------------------------------------------\n'
+    )
+    pr.notice(
+        'You can safely interrupt the download at any time with [bold yellow]Ctrl+C[/bold yellow].\n'
+    )
+    if DownloadContentTypeFilter.external_videos in content_type_filter:
+        pr.notice(
+            'Progress bar for external videos downloadings can be glitchy, because yt-dlp downloads them by chunks.\n'
+            "If you see strange progress movement that's normal in most cases, just be patient.\n"
+        )
+
+
+async def _download_handler(  # noqa: PLR0913
+    *,
+    username: str,
+    post_url: str | None,
+    content_type_filter: list[DownloadContentTypeFilter],
+    preferred_video_quality: VideoQualityOption,
+    request_delay_seconds: float,
+    destination_directory: Path | None,
+    cache_directory: Path | None,
+) -> None:
+    async with initialized_app(
+        username=username,
+        request_delay_seconds=request_delay_seconds,
+        destination_directory=destination_directory,
+        cache_directory=cache_directory,
+    ) as app_env:
+        downloading_context = DownloadContext(
+            author_name=username,
+            downloader_session=app_env.downloading_retry_client,
+            external_videos_downloader=ExternalVideosDownloader(),
+            filters=content_type_filter,
+            post_cache=app_env.post_cache,
+            preferred_video_quality=preferred_video_quality.to_ok_video_type(),
+            progress_reporter=app_env.progress_reporter,
+            failed_logger=FailedDownloadsLogger(
+                log_file_path=app_env.destination_directory / 'failed_downloads.log',
+            ),
+        )
+
+        if post_url is not None:
+            await DownloadPostByUrlUseCase(
+                post_url=post_url,
+                boosty_api=app_env.boosty_api_client,
+                destination=app_env.destination_directory,
+                download_context=downloading_context,
+            ).execute()
+            return
+
+        _show_start_summary(
+            pr=app_env.progress_reporter,
+            destination_directory=app_env.destination_directory,
+            content_type_filter=content_type_filter,
+        )
+
+        await DownloadAllPostUseCase(
+            author_name=username,
+            boosty_api=app_env.boosty_api_client,
+            destination=app_env.destination_directory,
+            download_context=downloading_context,
+        ).execute()
+
+
+def register(app: typer.Typer) -> None:
+    """Register the download command."""
+
+    @app.command(
+        'download',
+        short_help='Download posts from a Boosty creator.',
+    )
+    def download_entrypoint(  # noqa: PLR0913
+        *,
+        username: UsernameOption,
+        request_delay_seconds: RequestDelaySecondsOption = 2.5,
+        post_url: PostUrlOption = None,
+        content_type_filter: ContentTypeFilterOption = None,
+        preferred_video_quality: PreferredVideoQualityOption = VideoQualityOption.medium,
+        destination_directory: DestinationDirectoryOption = None,
+        cache_directory: CacheDirectoryOption = None,
+    ) -> None:
+        """
+        Download posts from a Boosty creator.
+
+        [bold]DETAILS:[/bold]
+
+            - Use `--post-url` to download a specific post.
+            - By default, downloads all posts from newest to oldest with all available contents.
+            - Unavailable posts are skipped, and you will be notified about them.
+
+
+        [bold]CONTENT FILTERING:[/bold]
+
+            - Use multiple `-f` flags to select content types (all included by default).
+            - Example: [italic]boosty-downloader download --username <USERNAME> -f files -f post_content[/italic]
+            - [bold red]NOTE:[/bold red] If you specify [italic]post_content[/italic] without [italic]boosty_videos[/italic] or [italic]external_videos[/italic],
+                    videos won't attach to post previews due to cache limitations.
+            - For best results, just leave all filters by default.
+
+
+        [bold]RATE LIMITING:[/bold]
+
+            - Increase request delay (default 2.5s) if you get errors.
+            - Please avoid spamming the API.
+
+
+        [bold]ABOUT CONTENT SYNC & CACHING:[/bold]
+
+            - Downloaded content is cached automatically to avoid duplicates.
+            - Downloading the same post with different filters downloads only missing parts.
+            - Posts updated by creators are fully re-downloaded.
+            - Cache doesn't check local files, you can delete them and they still won't re-download.
+
+        """
+        asyncio.run(
+            _download_handler(
+                username=username,
+                post_url=post_url,
+                content_type_filter=(
+                    content_type_filter
+                    if content_type_filter
+                    else list(DownloadContentTypeFilter)
+                ),
+                preferred_video_quality=preferred_video_quality,
+                request_delay_seconds=request_delay_seconds,
+                destination_directory=destination_directory,
+                cache_directory=cache_directory,
+            ),
+        )

--- a/boosty_downloader/src/cli/commands/show_auth_script.py
+++ b/boosty_downloader/src/cli/commands/show_auth_script.py
@@ -1,0 +1,22 @@
+"""CLI command: show JavaScript helper for extracting Boosty credentials."""
+
+# pyright: reportUnusedFunction=false
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from boosty_downloader.src.cli.boosty_token_viewer import (
+    show_js_helper_script,
+)
+
+if TYPE_CHECKING:
+    import typer
+
+
+def register(app: typer.Typer) -> None:
+    """Register the show-auth-script command."""
+
+    @app.command('show-auth-script')
+    def show_auth_script_entrypoint() -> None:
+        """Show a JS helper script to extract Boosty credentials from browser console."""
+        show_js_helper_script()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1218,6 +1218,18 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+description = "A cross-platform clipboard module for Python. (Only handles plain text for now.)"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273"},
+    {file = "pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6"},
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.407"
 description = "Command line wrapper for pyright"
@@ -1801,4 +1813,4 @@ test = ["pytest (>=8.1,<9.0)", "pytest-rerunfailures (>=14.0,<15.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "bed26a8a2cddeeaeb6a56057d9103dad81ba0b2e1bc8a0faa568aff2ba9fd1ac"
+content-hash = "ce3dc1f801062a9cf64c4671a854f8fe2eb6115f05378abcc233bed18f25783a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "sqlalchemy (>=2.0.42,<3.0.0)",
     "aiolimiter (>=1.2.1,<2.0.0)",
     "packaging (>=25.0,<26.0)",
+    "pyperclip (>=1.9.0,<2.0.0)",
 ]
 
 [project.scripts]

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,8 +18,18 @@ lint.ignore = [
 ]
 
 [lint.per-file-ignores]
+# D: no docstrings needed in tests
+# ANN201: test functions always return None, no need to annotate
+# S101: pytest is built on assert
+# PLR2004: magic numbers are fine in test assertions
+# INP001: test dir is not a package, no __init__.py needed
 "test/*" = ["D", "ANN201", "S101", "PLR2004", "INP001"]
-"scripts/*" = ["T201", "INP001"]
+# T201: dev scripts may use print()
+# INP001: scripts dir is not a package
+# S603: subprocess with fixed args in trusted dev scripts
+# S607: partial executable path (poetry, pip) is fine for dev scripts
+"scripts/*" = ["T201", "INP001", "S603", "S607"]
+# D104: __init__.py files are often empty or re-exports only
 "__init__.py" = ["D104"]
 
 [format]

--- a/scripts/build_install.py
+++ b/scripts/build_install.py
@@ -60,7 +60,16 @@ def main() -> None:
 
     console.print(f'  [dim]3.[/] Installing globally via [cyan]{global_python}[/]...')
     subprocess.run(
-        [str(global_python), '-m', 'pip', 'install', '--user', '--force-reinstall', '--no-deps', str(wheel)],
+        [
+            str(global_python),
+            '-m',
+            'pip',
+            'install',
+            '--user',
+            '--force-reinstall',
+            '--no-deps',
+            str(wheel),
+        ],
         check=True,
     )
 

--- a/scripts/build_install.py
+++ b/scripts/build_install.py
@@ -1,0 +1,77 @@
+"""Build wheel and install it locally for testing."""
+
+from __future__ import annotations
+
+import io
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from rich.console import Console
+
+DIST_DIR = Path('dist')
+PYPROJECT = Path('pyproject.toml')
+
+sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', errors='replace')
+console = Console(force_terminal=True)
+
+
+def _get_version() -> str:
+    text = PYPROJECT.read_text(encoding='utf-8')
+    m = re.search(r'version = "([^"]*)"', text)
+    return m.group(1) if m else '?'
+
+
+def main() -> None:
+    """Clean dist/, build a fresh wheel, install it with pip."""
+    version = _get_version()
+
+    console.print()
+    console.print(f'  :package: [bold]boosty-downloader[/] [cyan]v{version}[/]')
+    console.print()
+
+    # --- Step 1: Clean dist/ -------------------------------------------------
+    if DIST_DIR.exists():
+        shutil.rmtree(DIST_DIR)
+    console.print('  [dim]1.[/] Cleaned dist/')
+
+    # --- Step 2: Build -------------------------------------------------------
+    console.print('  [dim]2.[/] Building wheel...')
+    subprocess.run(
+        ['poetry', 'build', '--no-cache'],
+        check=True,
+    )
+
+    wheels = list(DIST_DIR.glob('*.whl'))
+    if not wheels:
+        console.print('  [red bold]Error:[/] no .whl found in dist/')
+        sys.exit(1)
+
+    wheel = wheels[0]
+    console.print(f'     [green]{wheel.name}[/]')
+
+    # --- Step 3: Install to user site-packages ----------------------------------
+    # Use base Python (not venv) so --user works even from activated venv.
+    global_python = Path(sys.base_prefix) / 'python.exe'
+    if not global_python.exists():
+        global_python = Path(sys.base_prefix) / 'bin' / 'python'
+
+    console.print(f'  [dim]3.[/] Installing globally via [cyan]{global_python}[/]...')
+    subprocess.run(
+        [str(global_python), '-m', 'pip', 'install', '--user', '--force-reinstall', '--no-deps', str(wheel)],
+        check=True,
+    )
+
+    # --- Done ----------------------------------------------------------------
+    console.print()
+    console.print(f'  :white_check_mark: [green bold]Installed v{version} globally[/]')
+    console.print()
+    console.print('  [dim]Test it:[/]')
+    console.print('  [cyan]boosty-downloader --help[/]')
+    console.print()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## 📝 Summary

**New `show-auth-script` subcommand** that outputs a JS snippet for extracting Boosty auth credentials from the browser console. Copies to clipboard automatically via pyperclip.

**CLI restructured into subcommands**: `download`, `check`, `clean-cache`, `show-auth-script` - each in its own module under `cli/commands/`. This is a breaking change:

```bash
# Before
boosty-downloader --username author
boosty-downloader --username author --only-check-total
boosty-downloader --username author --clean-cache

# After
boosty-downloader download --username author
boosty-downloader check --username author
boosty-downloader clean-cache --username author
boosty-downloader show-auth-script
```

Why this is better: the flow of each command is independent and clean, and the user is focused on the task instead of combination of flags.

`main.py` reduced from ~380 to ~80 lines. Initialization logic extracted to `application/di/initialized_app.py`. `clean-cache` works directly with SQLitePostCache without creating an HTTP session.

Added `make build-install` for quick global install testing.

## 🎯 Related Issue

## ✅ Checklist

- [x] Locally tested (`make test`)
- [x] CI checks pass (`make ci-check`)
- [x] Added a line to `## Unreleased` section in CHANGELOG.md describing the change (or added `ci/skip-changelog` label if not user-facing)