### PR TITLE
Expose message on download errors

### DIFF
--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -60,6 +60,7 @@ class DownloadError(Exception):
 
     def __init__(self, message: str, file: Path | None, resource_url: str) -> None:
         super().__init__(message)
+        self.message = message
         self.file = file
         self.resource_url = resource_url
 

--- a/test/unit/file_downloader/download_errors_test.py
+++ b/test/unit/file_downloader/download_errors_test.py
@@ -1,0 +1,27 @@
+from boosty_downloader.src.infrastructure.file_downloader import (
+    DownloadError,
+    DownloadUnexpectedStatusError,
+)
+
+
+def test_download_error_exposes_message_attribute():
+    error = DownloadError(
+        message='Download failed',
+        file=None,
+        resource_url='https://example.com/file.bin',
+    )
+
+    assert error.message == 'Download failed'
+    assert str(error) == 'Download failed'
+
+
+def test_unexpected_status_error_exposes_message_attribute():
+    error = DownloadUnexpectedStatusError(
+        status=400,
+        response_message='Bad Request',
+        resource_url='https://example.com/video.mp4',
+    )
+
+    assert error.message == 'Unexpected status code: 400'
+    assert str(error) == 'Unexpected status code: 400'
+    assert error.resource_url == 'https://example.com/video.mp4'


### PR DESCRIPTION
Fixes #105.

The crash happens because DownloadSinglePostUseCase._safely_process_chunk() logs and wraps lower-level download failures with e.message, but the DownloadError base class never assigned the message attribute it declares. DownloadUnexpectedStatusError therefore has a useful str(e), but no e.message, so the error handler raises an AttributeError while trying to report the original download failure.

This sets self.message in DownloadError.__init__, which keeps the existing application-level handling intact for all current DownloadError subclasses instead of patching one call site. I added unit coverage for the base error and DownloadUnexpectedStatusError so the attribute stays in sync with the exception text.

Checked locally:
- python -m pytest test/unit/file_downloader/download_errors_test.py
- python -m pytest test/unit
- python -m py_compile boosty_downloader/src/infrastructure/file_downloader.py test/unit/file_downloader/download_errors_test.py
- python -m ruff check boosty_downloader/src/infrastructure/file_downloader.py test/unit/file_downloader/download_errors_test.py
- git diff --check