### PR TITLE
ci: Auto-label Renovate PRs to skip the changelog gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
 
   "dependencyDashboard": true,
   "baseBranches": [ "main" ],
+  "labels": [ "ci/skip-changelog" ],
 
   "schedule": [ "on saturday" ],
   "prHourlyLimit": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+- Fix crash on failed downloads: show a readable error message instead of an AttributeError traceback (#105, #89)
+- Update yt-dlp to 2026.7.4: fixes external video downloading (security update)
+
 ## 3.0.0
 
 - MAJOR: New way of calling commands (use subcommands for different scenario)


### PR DESCRIPTION
- `renovate.json`: add `labels: ["ci/skip-changelog"]` so future Renovate PRs pass the CHANGELOG gate on their own (the bot never writes changelogs - all five security PRs sat red on this check for months).
- `CHANGELOG.md`: add Unreleased entries for the download-error crash fix (#105, #89) and the yt-dlp security update, so the v3.1.0 release notes are ready.