### PR TITLE
[boosty-api] Fix wrong-username errors and non-JSON body crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix crash on failed downloads: show a readable error message instead of an AttributeError traceback (#105, #89)
 - Update yt-dlp to 2026.7.4: fixes external video downloading (security update)
 - Fix running download/check without --username: clear "Missing option" error and exit code 2 instead of a crash
+- Fix confusing "Unknown error" for a wrong username: clear "author not found" message and a hint about the blog name (#94)
 
 ## 3.0.0
 

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -16,6 +16,7 @@ from boosty_downloader.src.cli.commands import (
     show_auth_script,
 )
 from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPIInvalidUsernameError,
     BoostyAPINoUsernameError,
     BoostyAPIUnauthorizedError,
     BoostyAPIUnknownError,
@@ -55,8 +56,17 @@ def entry_point() -> None:
     """Run the CLI app with top-level error handling."""
     try:
         typer_app()
-    except BoostyAPINoUsernameError:
-        logger_instances.downloader_logger.error('Username not found')
+    except BoostyAPINoUsernameError as e:
+        logger_instances.downloader_logger.error(
+            f"Author '{e.username}' not found. "
+            'Username is the blog name from the author page URL: boosty.to/<username>'
+        )
+    except BoostyAPIInvalidUsernameError as e:
+        logger_instances.downloader_logger.error(
+            f"'{e.username}' is not a valid username. "
+            'Use the blog name from the author page URL (boosty.to/<username>), '
+            'not an email'
+        )
     except BoostyAPIUnauthorizedError:
         logger_instances.downloader_logger.error(
             'Unauthorized: Bad credentials, please relogin and update your config file'

--- a/boosty_downloader/src/infrastructure/boosty_api/core/client.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/core/client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from http import HTTPStatus
 from typing import TYPE_CHECKING
 
+from aiohttp import ContentTypeError
 from aiolimiter import AsyncLimiter
 from pydantic import ValidationError
 from yarl import URL
@@ -40,6 +42,16 @@ class BoostyAPINoUsernameError(BoostyAPIError):
 
     def __init__(self, username: str) -> None:
         super().__init__(f'Username not found: {username}')
+        self.username = username
+
+
+class BoostyAPIInvalidUsernameError(BoostyAPIError):
+    """Raised when Boosty rejects the username format."""
+
+    username: str
+
+    def __init__(self, username: str) -> None:
+        super().__init__(f'Invalid username: {username}')
         self.username = username
 
 
@@ -146,8 +158,6 @@ class BoostyAPIClient:
                 },
             ),
         )
-        posts_data = await posts_raw.json()
-
         if posts_raw.status == HTTPStatus.NOT_FOUND:
             raise BoostyAPINoUsernameError(author_name)
 
@@ -155,10 +165,22 @@ class BoostyAPIClient:
         if posts_raw.status == HTTPStatus.UNAUTHORIZED:
             raise BoostyAPIUnauthorizedError
 
+        # Boosty answers 400 (invalid_param) to a malformed blog name, e.g. an email
+        if posts_raw.status == HTTPStatus.BAD_REQUEST:
+            raise BoostyAPIInvalidUsernameError(author_name)
+
         if posts_raw.status != HTTPStatus.OK:
             raise BoostyAPIUnknownError(
                 posts_raw.status, f'Unexpected status code: {posts_raw.status}'
             )
+
+        # Status is OK here, so a non-JSON body means a broken response
+        try:
+            posts_data = await posts_raw.json()
+        except (ContentTypeError, json.JSONDecodeError) as e:
+            raise BoostyAPIUnknownError(
+                posts_raw.status, 'Non-JSON response from the API'
+            ) from e
 
         try:
             posts: list[PostDTO] = [

--- a/test/unit/boosty_api/client_test.py
+++ b/test/unit/boosty_api/client_test.py
@@ -1,0 +1,131 @@
+"""Regression tests for BoostyAPIClient error mapping (status checks before body parsing)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from aiohttp import ContentTypeError
+
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPIClient,
+    BoostyAPIInvalidUsernameError,
+    BoostyAPINoUsernameError,
+    BoostyAPIUnauthorizedError,
+    BoostyAPIUnknownError,
+)
+
+if TYPE_CHECKING:
+    from aiohttp import RequestInfo
+    from aiohttp_retry import RetryClient
+
+
+class _JsonMustNotBeCalledError(AssertionError):
+    """Raised by the fake response when a test forbids body parsing."""
+
+
+@dataclass
+class _FakeResponse:
+    """Prepared HTTP response: a status plus either a JSON body or a parse error."""
+
+    status: int
+    json_data: Any = None
+    json_error: Exception | None = None
+
+    async def json(self) -> object:
+        if self.json_error is not None:
+            raise self.json_error
+        return self.json_data
+
+
+class _FakeSession:
+    """Stub of RetryClient: returns the one prepared response for any GET."""
+
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def get(self, *args: object, **kwargs: object) -> _FakeResponse:
+        del args, kwargs  # the stub answers any request the same way
+        return self._response
+
+
+def _make_client(response: _FakeResponse) -> BoostyAPIClient:
+    return BoostyAPIClient(session=cast('RetryClient', _FakeSession(response)))
+
+
+VALID_EXTRA: Any = {'offset': '', 'isLast': True}
+
+
+@pytest.mark.asyncio
+async def test_404_maps_to_no_username_error_without_parsing_body():
+    client = _make_client(
+        _FakeResponse(status=404, json_error=_JsonMustNotBeCalledError())
+    )
+
+    with pytest.raises(BoostyAPINoUsernameError) as exc_info:
+        await client.get_author_posts('ghost_author', limit=1)
+
+    assert exc_info.value.username == 'ghost_author'
+
+
+@pytest.mark.asyncio
+async def test_401_maps_to_unauthorized_error_without_parsing_body():
+    client = _make_client(
+        _FakeResponse(status=401, json_error=_JsonMustNotBeCalledError())
+    )
+
+    with pytest.raises(BoostyAPIUnauthorizedError):
+        await client.get_author_posts('any_author', limit=1)
+
+
+@pytest.mark.asyncio
+async def test_400_maps_to_invalid_username_error_without_parsing_body():
+    client = _make_client(
+        _FakeResponse(status=400, json_error=_JsonMustNotBeCalledError())
+    )
+
+    with pytest.raises(BoostyAPIInvalidUsernameError) as exc_info:
+        await client.get_author_posts('someone@gmail.com', limit=1)
+
+    assert exc_info.value.username == 'someone@gmail.com'
+
+
+@pytest.mark.asyncio
+async def test_unexpected_status_maps_to_unknown_error():
+    client = _make_client(
+        _FakeResponse(status=500, json_error=_JsonMustNotBeCalledError())
+    )
+
+    with pytest.raises(BoostyAPIUnknownError):
+        await client.get_author_posts('any_author', limit=1)
+
+
+@pytest.mark.parametrize(
+    'parse_error',
+    [
+        ContentTypeError(cast('RequestInfo', None), ()),
+        json.JSONDecodeError('Expecting value', '<html></html>', 0),
+    ],
+    ids=['wrong_content_type', 'broken_json_body'],
+)
+@pytest.mark.asyncio
+async def test_200_with_non_json_body_maps_to_unknown_error(parse_error: Exception):
+    client = _make_client(_FakeResponse(status=200, json_error=parse_error))
+
+    with pytest.raises(BoostyAPIUnknownError):
+        await client.get_author_posts('any_author', limit=1)
+
+
+@pytest.mark.asyncio
+async def test_200_with_valid_empty_page_returns_posts_response():
+    client = _make_client(
+        _FakeResponse(status=200, json_data={'data': [], 'extra': VALID_EXTRA})
+    )
+
+    response = await client.get_author_posts('any_author', limit=1)
+
+    assert response.posts == []
+    assert response.extra.is_last is True
+    assert response.extra.offset == ''


### PR DESCRIPTION
## Summary

Wrong usernames now get clear messages instead of a scary "report this at GitHub" error, and a non-JSON reply from the API no longer crashes the app. Fixes #94.

## Problem

- The client parsed the response body before looking at the status code
- So an error reply with a non-JSON body (e.g. a DDoS-protection challenge page) crashed with a raw ContentTypeError traceback
- A typo in the username (404) printed a bare "Username not found" without the name or any hint
- An email instead of a username (Boosty answers 400 `invalid_param`) fell into the generic "Unknown error occurred, please report this at GitHub issues" - that is how #94 was born

## Fix

- Check the status code first: 404, 401, 400, then everything else
- New `BoostyAPIInvalidUsernameError` for 400 with its own message for the email case
- Parse the body only after the status checks; a non-JSON body on 200 maps to `BoostyAPIUnknownError`
- Both username messages show the entered name and a hint: username is the blog name from boosty.to/&lt;name&gt;

## Before / After

**Before:** `download -u someone@gmail.com` ends with "Unknown error occurred, please report this at GitHub issues".

**After:** it says "'someone@gmail.com' is not a valid username. Use the blog name from the author page URL (boosty.to/&lt;username&gt;), not an email".

## Tests

- `test_404_maps_to_no_username_error_without_parsing_body` - 404 gives "author not found" and the body is never parsed
- `test_401_maps_to_unauthorized_error_without_parsing_body` - expired tokens keep the "relogin" message
- `test_400_maps_to_invalid_username_error_without_parsing_body` - the email case from #94
- `test_unexpected_status_maps_to_unknown_error` - 5xx with an HTML body no longer crashes
- `test_200_with_non_json_body_maps_to_unknown_error` - wrong content-type and broken JSON on 200 map to a clear error
- `test_200_with_valid_empty_page_returns_posts_response` - the happy path still parses

## Notes

- Error reply shapes (400 `invalid_param`, 404 `blog_not_found`) checked by hand against the live API
