### PR TITLE
[boosty-api] Survive unknown Boosty content instead of crashing the download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - Update yt-dlp to 2026.7.4: fixes external video downloading (security update)
 - Fix running download/check without --username: clear "Missing option" error and exit code 2 instead of a crash
 - Fix confusing "Unknown error" for a wrong username: clear "author not found" message and a hint about the blog name (#94)
+- Survive unknown Boosty content: new types and values are kept, skipped where needed, and listed in a final summary with exact paths instead of crashing the whole download
+- Broken posts no longer fail the whole page: they are skipped with a readable warning, and validation errors are shown as short lines instead of raw dumps
 
 ## 3.0.0
 

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -22,6 +22,9 @@ from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIUnknownError,
     BoostyAPIValidationError,
 )
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_validation_errors,
+)
 from boosty_downloader.src.infrastructure.loggers import logger_instances
 
 typer_app = typer.Typer(
@@ -76,11 +79,14 @@ def entry_point() -> None:
             f'Unknown error occurred, please report this at GitHub issues of the project: {GITHUB_ISSUES_URL}'
         )
     except BoostyAPIValidationError as e:
+        details = '\n'.join(
+            f'  - {line}' for line in format_validation_errors(e.errors)
+        )
         logger_instances.downloader_logger.error(
             'Boosty API returned unexpected structures, the client probably needs to be updated.\n'
             f'Please report this at GitHub issues of the project: {GITHUB_ISSUES_URL}\n'
             '\n'
-            f'Details: {e.errors!s}'
+            f'{details}'
         )
     except ApplicationCancelledError:
         logger_instances.downloader_logger.warning(

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -23,6 +23,7 @@ from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIValidationError,
 )
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    GITHUB_ISSUES_URL,
     format_validation_errors,
 )
 from boosty_downloader.src.infrastructure.loggers import logger_instances
@@ -32,8 +33,6 @@ typer_app = typer.Typer(
     rich_markup_mode='rich',
     invoke_without_command=True,
 )
-
-GITHUB_ISSUES_URL = 'https://github.com/Glitchy-Sheep/boosty-downloader/issues'
 
 
 @typer_app.callback()

--- a/boosty_downloader/src/application/mappers/list.py
+++ b/boosty_downloader/src/application/mappers/list.py
@@ -23,6 +23,7 @@ from boosty_downloader.src.domain.post_data_chunks import (
     PostDataChunkTextualList,
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_list import (
+    BoostyListItemType,
     BoostyPostDataListDTO,
     BoostyPostDataListItemDTO,
 )
@@ -41,7 +42,7 @@ def to_domain_list_chunk(post_list: BoostyPostDataListDTO) -> PostDataChunkTextu
         # Convert data items to domain text chunks
         domain_data: list[PostDataChunkText] = []
         for data_item in api_item.data:
-            if data_item.type == 'text':
+            if data_item.type is BoostyListItemType.text:
                 # Create proper DTO object for the text mapper
                 text_dto = BoostyPostDataTextDTO(
                     type='text',

--- a/boosty_downloader/src/application/mappers/post_mapper.py
+++ b/boosty_downloader/src/application/mappers/post_mapper.py
@@ -21,6 +21,11 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
     BoostyPostDataListDTO,
     BoostyPostDataOkVideoDTO,
     BoostyPostDataTextDTO,
+    BoostyPostDataUnknownDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+    collect_unknown_content,
 )
 
 if TYPE_CHECKING:
@@ -40,6 +45,11 @@ class PostMappingResult:
     incomplete_content_types: set[DownloadContentTypeFilter] = field(
         default_factory=lambda: set[DownloadContentTypeFilter]()
     )
+    # Content this client doesn't know yet, raw. Rendering it for the user
+    # is the output layer's job (inline warnings and the run summary).
+    unknown_content: set[UnknownContent] = field(
+        default_factory=lambda: set[UnknownContent]()
+    )
 
 
 def map_post_dto_to_domain(  # noqa: C901
@@ -57,6 +67,9 @@ def map_post_dto_to_domain(  # noqa: C901
     )
 
     incomplete_content_types: set[DownloadContentTypeFilter] = set()
+    # One type-driven walk over the whole parsed post: any tolerant field
+    # or unknown chunk is reported automatically, wherever it sits.
+    unknown_content = collect_unknown_content(post_dto)
 
     for data_chunk in post_dto.data:
         match data_chunk:
@@ -96,8 +109,12 @@ def map_post_dto_to_domain(  # noqa: C901
                     incomplete_content_types.add(DownloadContentTypeFilter.audio)
                     continue
                 post.post_data_chunks.append(mappers.to_domain_audio_chunk(data_chunk))
+            case BoostyPostDataUnknownDTO():
+                # Reported by collect_unknown_content; nothing to map here.
+                pass
 
     return PostMappingResult(
         post=post,
         incomplete_content_types=incomplete_content_types,
+        unknown_content=unknown_content,
     )

--- a/boosty_downloader/src/application/use_cases/check_total_posts.py
+++ b/boosty_downloader/src/application/use_cases/check_total_posts.py
@@ -1,9 +1,21 @@
 """Use case for reporting the total number of posts and their accessibility for a given Boosty author."""
 
+from typing import TYPE_CHECKING
+
 from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIClient,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+    collect_unknown_content,
+)
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+        SkippedPost,
+    )
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_run_summary,
     format_skipped_post,
 )
 from boosty_downloader.src.infrastructure.loggers.logger_instances import RichLogger
@@ -35,11 +47,18 @@ class ReportTotalPostsCountUseCase:
         inaccessible_posts_count = 0
         inaccessible_posts_names: list[str] = []
 
+        all_skipped: list[SkippedPost] = []
+        unknown_content: set[UnknownContent] = set()
+
         async for page in self.boosty_api.iterate_over_posts(
             self.author_name, posts_per_page=100
         ):
             current_page += 1
             total_posts += len(page.posts)
+
+            all_skipped.extend(page.skipped_posts)
+            for post in page.posts:
+                unknown_content |= collect_unknown_content(post)
 
             for skipped in page.skipped_posts:
                 self.logger.warning(format_skipped_post(skipped))
@@ -66,3 +85,7 @@ class ReportTotalPostsCountUseCase:
             '\n'
             f'[bold]{inaccessible_titles_str}[/bold]'
         )
+
+        summary = format_run_summary(all_skipped, unknown_content)
+        if summary:
+            self.logger.warning(summary)

--- a/boosty_downloader/src/application/use_cases/check_total_posts.py
+++ b/boosty_downloader/src/application/use_cases/check_total_posts.py
@@ -3,6 +3,9 @@
 from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIClient,
 )
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_skipped_post,
+)
 from boosty_downloader.src.infrastructure.loggers.logger_instances import RichLogger
 
 
@@ -37,6 +40,9 @@ class ReportTotalPostsCountUseCase:
         ):
             current_page += 1
             total_posts += len(page.posts)
+
+            for skipped in page.skipped_posts:
+                self.logger.warning(format_skipped_post(skipped))
 
             self.logger.info(
                 f'Processing page [bold]{current_page}[/bold]'

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -12,6 +12,9 @@ from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
 )
 from boosty_downloader.src.infrastructure.boosty_api.core.client import BoostyAPIClient
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_skipped_post,
+)
 from boosty_downloader.src.infrastructure.path_sanitizer import (
     sanitize_string,
 )
@@ -50,6 +53,9 @@ class DownloadAllPostUseCase:
         async for page in posts_iterator:
             count = len(page.posts)
             current_page += 1
+
+            for skipped in page.skipped_posts:
+                self.context.progress_reporter.warn(format_skipped_post(skipped))
 
             page_task_id = self.context.progress_reporter.create_task(
                 f'Got new posts: [{count}]',

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.exceptions.application_errors import (
@@ -12,12 +13,23 @@ from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
 )
 from boosty_downloader.src.infrastructure.boosty_api.core.client import BoostyAPIClient
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+    collect_unknown_content,
+)
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_run_summary,
     format_skipped_post,
 )
 from boosty_downloader.src.infrastructure.path_sanitizer import (
     sanitize_string,
 )
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+        PostsResponse,
+        SkippedPost,
+    )
 
 
 class DownloadAllPostUseCase:
@@ -43,19 +55,33 @@ class DownloadAllPostUseCase:
         self.destination = destination
         self.context = download_context
 
+    def _note_page_anomalies(
+        self,
+        page: 'PostsResponse',
+        all_skipped: list['SkippedPost'],
+        unknown_content: set[UnknownContent],
+    ) -> None:
+        """Warn about skipped posts and collect everything unknown for the summary."""
+        all_skipped.extend(page.skipped_posts)
+        for post_dto in page.posts:
+            unknown_content |= collect_unknown_content(post_dto)
+        for skipped in page.skipped_posts:
+            self.context.progress_reporter.warn(format_skipped_post(skipped))
+
     async def execute(self) -> None:
         posts_iterator = self.boosty_api.iterate_over_posts(
             author_name=self.author_name
         )
 
         current_page = 0
+        all_skipped: list[SkippedPost] = []
+        unknown_content: set[UnknownContent] = set()
 
         async for page in posts_iterator:
             count = len(page.posts)
             current_page += 1
 
-            for skipped in page.skipped_posts:
-                self.context.progress_reporter.warn(format_skipped_post(skipped))
+            self._note_page_anomalies(page, all_skipped, unknown_content)
 
             page_task_id = self.context.progress_reporter.create_task(
                 f'Got new posts: [{count}]',
@@ -120,3 +146,7 @@ class DownloadAllPostUseCase:
             self.context.progress_reporter.success(
                 f'--- Finished page {current_page} ---'
             )
+
+        summary = format_run_summary(all_skipped, unknown_content)
+        if summary:
+            self.context.progress_reporter.warn(summary)

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -1,6 +1,8 @@
 """Use case for downloading a specific Boosty post by URL."""
 
+from enum import Enum, auto
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.exceptions.application_errors import (
@@ -13,7 +15,31 @@ from boosty_downloader.src.application.use_cases.download_single_post import (
     ApplicationFailedDownloadError,
     DownloadSinglePostUseCase,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    collect_unknown_content,
+)
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    GITHUB_ISSUES_URL,
+    format_run_summary,
+    format_skipped_post,
+)
 from boosty_downloader.src.infrastructure.file_downloader import sanitize_string
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.post import (
+        PostDTO,
+    )
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+        PostsResponse,
+    )
+
+
+class _PostDownloadOutcome(Enum):
+    """Outcome of downloading the found post."""
+
+    downloaded = auto()
+    failed = auto()
+    cancelled = auto()
 
 
 class DownloadPostByUrlUseCase:
@@ -63,6 +89,22 @@ class DownloadPostByUrlUseCase:
         else:
             return author, post_uuid
 
+    def _report_if_target_skipped(self, page: 'PostsResponse', post_uuid: str) -> bool:
+        """
+        Tell the user when the searched post exists but this client can't parse it.
+
+        A misleading "not found" would hide the real problem.
+        """
+        for skipped in page.skipped_posts:
+            if skipped.post_id == post_uuid:
+                self.context.progress_reporter.error(format_skipped_post(skipped))
+                self.context.progress_reporter.error(
+                    f'Please report this at {GITHUB_ISSUES_URL} '
+                    'so the client can be updated.'
+                )
+                return True
+        return False
+
     async def execute(self) -> None:
         author_name, post_uuid = self.extract_author_and_uuid_from_url()
         if not author_name or not post_uuid:
@@ -80,36 +122,50 @@ class DownloadPostByUrlUseCase:
             self.context.progress_reporter.info(
                 f'[Page({current_page})] Searching for the post with UUID: {post_uuid}... '
             )
+            if self._report_if_target_skipped(page, post_uuid):
+                return
+
             for post in page.posts:
                 if post.id == post_uuid:
-                    self.context.progress_reporter.success(
-                        f'Found post with UUID: {post_uuid}, starting download...'
-                    )
-
-                    post_title = post.title
-                    if len(post_title) == 0:
-                        post_title = f'No title (id_{post.id[:8]})'
-
-                    post_name = f'{post.created_at.date()} - {post_title}'
-                    post_name = sanitize_string(post_name).replace('.', '').strip()
-
-                    try:
-                        await DownloadSinglePostUseCase(
-                            post_dto=post,
-                            destination=self.destination / post_name,
-                            download_context=self.context,
-                        ).execute()
-                    except ApplicationCancelledError:
-                        self.context.progress_reporter.warn(
-                            'Download cancelled by user. Bye!'
-                        )
-                    except ApplicationFailedDownloadError as e:
-                        self.context.progress_reporter.error(
-                            f'Failed to download post: {e.message}, RESOURCE: ({e.resource})'
-                        )
-                    else:
+                    outcome = await self._download_post(post)
+                    if outcome is _PostDownloadOutcome.downloaded:
                         return
+                    # Note: cancel does not stop the search - it moves on
+                    # like a failed download.
 
         self.context.progress_reporter.error(
             'Failed to find and download the specified post.'
         )
+
+    async def _download_post(self, post: 'PostDTO') -> _PostDownloadOutcome:
+        """Download the found post and name how it went."""
+        self.context.progress_reporter.success(
+            f'Found post with UUID: {post.id}, starting download...'
+        )
+
+        summary = format_run_summary([], collect_unknown_content(post))
+        if summary:
+            self.context.progress_reporter.warn(summary)
+
+        post_title = post.title
+        if len(post_title) == 0:
+            post_title = f'No title (id_{post.id[:8]})'
+
+        post_name = f'{post.created_at.date()} - {post_title}'
+        post_name = sanitize_string(post_name).replace('.', '').strip()
+
+        try:
+            await DownloadSinglePostUseCase(
+                post_dto=post,
+                destination=self.destination / post_name,
+                download_context=self.context,
+            ).execute()
+        except ApplicationCancelledError:
+            self.context.progress_reporter.warn('Download cancelled by user. Bye!')
+            return _PostDownloadOutcome.cancelled
+        except ApplicationFailedDownloadError as e:
+            self.context.progress_reporter.error(
+                f'Failed to download post: {e.message}, RESOURCE: ({e.resource})'
+            )
+            return _PostDownloadOutcome.failed
+        return _PostDownloadOutcome.downloaded

--- a/boosty_downloader/src/infrastructure/boosty_api/core/client.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/core/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from http import HTTPStatus
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from aiohttp import ContentTypeError
 from aiolimiter import AsyncLimiter
@@ -18,6 +18,7 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Ex
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
     PostsResponse,
+    SkippedPost,
 )
 from boosty_downloader.src.infrastructure.boosty_api.utils.filter_none_params import (
     filter_none_params,
@@ -182,10 +183,30 @@ class BoostyAPIClient:
                 posts_raw.status, 'Non-JSON response from the API'
             ) from e
 
+        # Posts are validated one by one: a post this client can't parse
+        # must not fail the page - the caller reports it and the run goes on.
+        posts: list[PostDTO] = []
+        skipped_posts: list[SkippedPost] = []
+        for raw_post in posts_data['data']:
+            try:
+                posts.append(PostDTO.model_validate(raw_post))
+            except ValidationError as e:  # noqa: PERF203 per-post isolation is the point here
+                raw_info: dict[str, object] = (
+                    cast('dict[str, object]', raw_post)
+                    if isinstance(raw_post, dict)
+                    else {}
+                )
+                skipped_posts.append(
+                    SkippedPost(
+                        post_id=str(raw_info.get('id', '<no id>')),
+                        title=str(raw_info.get('title', '<no title>')),
+                        errors=e.errors(),
+                    )
+                )
+
+        # Pagination info is different: without it the walk can't continue,
+        # so a broken 'extra' is still an error for the whole page.
         try:
-            posts: list[PostDTO] = [
-                PostDTO.model_validate(post) for post in posts_data['data']
-            ]
             extra: Extra = Extra.model_validate(posts_data['extra'])
         except ValidationError as e:
             raise BoostyAPIValidationError(errors=e.errors()) from e
@@ -193,6 +214,7 @@ class BoostyAPIClient:
         return PostsResponse(
             posts=posts,
             extra=extra,
+            skipped_posts=skipped_posts,
         )
 
     async def iterate_over_posts(

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/base_post_data.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field, TypeAdapter, ValidationError
 
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types import (
     BoostyPostDataAudioDTO,
@@ -20,9 +20,10 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
     BoostyPostDataListDTO,
     BoostyPostDataOkVideoDTO,
     BoostyPostDataTextDTO,
+    BoostyPostDataUnknownDTO,
 )
 
-BasePostData = Annotated[
+KnownPostData = Annotated[
     BoostyPostDataTextDTO
     | BoostyPostDataAudioDTO
     | BoostyPostDataImageDTO
@@ -35,4 +36,32 @@ BasePostData = Annotated[
     Field(
         discriminator='type',
     ),
+]
+
+_KNOWN_POST_DATA = TypeAdapter[KnownPostData](KnownPostData)
+
+# Error kinds meaning "the type tag itself is unknown or absent",
+# as opposed to a known chunk arriving with a broken body.
+_UNKNOWN_TAG_ERRORS = frozenset({'union_tag_invalid', 'union_tag_not_found'})
+
+
+def _chunk_or_unknown(value: object) -> object:
+    """
+    Parse a post data chunk by its type tag.
+
+    A chunk with an unknown tag becomes BoostyPostDataUnknownDTO.
+    A known chunk with a broken body stays a validation error:
+    masking it as unknown would silently drop real content.
+    """
+    try:
+        return _KNOWN_POST_DATA.validate_python(value)
+    except ValidationError as e:
+        if all(err['type'] in _UNKNOWN_TAG_ERRORS for err in e.errors()):
+            return BoostyPostDataUnknownDTO.model_validate(value)
+        raise
+
+
+BasePostData = Annotated[
+    KnownPostData | BoostyPostDataUnknownDTO,
+    BeforeValidator(_chunk_or_unknown),
 ]

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/__init__.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/__init__.py
@@ -6,6 +6,7 @@ from .post_data_link import BoostyPostDataLinkDTO
 from .post_data_list import BoostyPostDataListDTO
 from .post_data_ok_video import BoostyPostDataOkVideoDTO
 from .post_data_text import BoostyPostDataTextDTO
+from .post_data_unknown import BoostyPostDataUnknownDTO
 from .post_data_video import BoostyPostDataExternalVideoDTO
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     'BoostyPostDataListDTO',
     'BoostyPostDataOkVideoDTO',
     'BoostyPostDataTextDTO',
+    'BoostyPostDataUnknownDTO',
 ]

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_list.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_list.py
@@ -1,16 +1,51 @@
 """The module with list representation of posts data"""
 
-from typing import Literal
+from enum import Enum
+from typing import Annotated, Literal
 
 from pydantic import Field
 
 from boosty_downloader.src.infrastructure.boosty_api.models.base import BoostyBaseDTO
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    UnknownValue,
+)
+
+
+class BoostyListStyle(Enum):
+    """List styles Boosty is known to send."""
+
+    ordered = 'ordered'
+    unordered = 'unordered'
+
+
+class BoostyListItemType(Enum):
+    """List sub-element types the list mapper understands."""
+
+    text = 'text'
+
+
+# Known sub-element types parse into the enum, anything new from Boosty is
+# kept as BoostyUnknownValue instead of failing the whole page. left_to_right
+# is required: the default smart mode lets the catch-all swallow known values.
+TolerantListItemType = Annotated[
+    BoostyListItemType | UnknownValue,
+    Field(union_mode='left_to_right'),
+]
+
+
+# Known styles parse into the enum, a new style from Boosty is kept as
+# BoostyUnknownValue instead of failing the whole page. left_to_right is
+# required: the default smart mode lets the catch-all swallow known values.
+TolerantListStyle = Annotated[
+    BoostyListStyle | None | UnknownValue,
+    Field(union_mode='left_to_right'),
+]
 
 
 class BoostyPostDataListDataItemDTO(BoostyBaseDTO):
     """Represents a single data item in a list of post data chunks."""
 
-    type: str
+    type: TolerantListItemType
     modificator: str | None = ''
     content: str
 
@@ -34,4 +69,4 @@ class BoostyPostDataListDTO(BoostyBaseDTO):
 
     type: Literal['list']
     items: list[BoostyPostDataListItemDTO]
-    style: Literal['ordered', 'unordered'] | None = None
+    style: TolerantListStyle = None

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
@@ -32,6 +32,15 @@ class BoostyOkVideoType(Enum):
     tiny = 'tiny'
     lowest = 'lowest'
 
+    # Fallback for url types this client doesn't know yet:
+    # Boosty adds new ones over time, they must parse fine
+    # and never win the quality ranking.
+    unknown = 'unknown'
+
+    @classmethod
+    def _missing_(cls, _value: object) -> BoostyOkVideoType:
+        return cls.unknown
+
 
 class BoostyOkVideoUrl(BoostyBaseDTO):
     """Link to video with specific format (link can be empty for some formats)"""

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
@@ -4,9 +4,14 @@ from __future__ import annotations
 
 from datetime import timedelta  # noqa: TC003 Pydantic should know this type fully
 from enum import Enum
-from typing import Literal
+from typing import Annotated, Literal
+
+from pydantic import Field
 
 from boosty_downloader.src.infrastructure.boosty_api.models.base import BoostyBaseDTO
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    UnknownValue,
+)
 
 
 class BoostyOkVideoType(Enum):
@@ -32,21 +37,21 @@ class BoostyOkVideoType(Enum):
     tiny = 'tiny'
     lowest = 'lowest'
 
-    # Fallback for url types this client doesn't know yet:
-    # Boosty adds new ones over time, they must parse fine
-    # and never win the quality ranking.
-    unknown = 'unknown'
 
-    @classmethod
-    def _missing_(cls, _value: object) -> BoostyOkVideoType:
-        return cls.unknown
+# Known types parse into the enum, anything new from Boosty is kept as
+# BoostyUnknownValue with the raw word for the run summary. left_to_right is
+# required: the default smart mode lets the catch-all swallow known values.
+TolerantOkVideoType = Annotated[
+    BoostyOkVideoType | UnknownValue,
+    Field(union_mode='left_to_right'),
+]
 
 
 class BoostyOkVideoUrl(BoostyBaseDTO):
     """Link to video with specific format (link can be empty for some formats)"""
 
     url: str
-    type: BoostyOkVideoType
+    type: TolerantOkVideoType
 
 
 class BoostyPostDataOkVideoDTO(BoostyBaseDTO):

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_unknown.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_unknown.py
@@ -1,0 +1,14 @@
+"""Fallback model for post data chunks of types this client doesn't know yet."""
+
+from boosty_downloader.src.infrastructure.boosty_api.models.base import BoostyBaseDTO
+
+
+class BoostyPostDataUnknownDTO(BoostyBaseDTO):
+    """
+    Post data chunk of a type this client doesn't know yet.
+
+    Boosty adds new content types over time. Such chunks parse into this
+    fallback, get skipped by the mapper and are reported in the run summary.
+    """
+
+    type: str = 'unknown'

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/posts_request.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/posts_request.py
@@ -1,13 +1,34 @@
 """Models for posts responses to boosty.to"""
 
-from pydantic import BaseModel
+from __future__ import annotations
 
-from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
-from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic_core import ErrorDetails
+
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 
 
-class PostsResponse(BaseModel):
-    """Model representing a response from a posts request"""
+@dataclass(frozen=True, slots=True)
+class SkippedPost:
+    """A post this client could not parse: identity plus raw validation details."""
+
+    post_id: str
+    title: str
+    errors: list[ErrorDetails]
+
+
+@dataclass
+class PostsResponse:
+    """One page of an author's posts, as parsed by the client."""
 
     posts: list[PostDTO]
     extra: Extra
+    # Posts with structures this client doesn't understand. Raw details here;
+    # rendering them for the user is the output layer's job.
+    skipped_posts: list[SkippedPost] = field(
+        default_factory=lambda: list[SkippedPost]()
+    )

--- a/boosty_downloader/src/infrastructure/boosty_api/models/unknown_content.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/unknown_content.py
@@ -1,0 +1,64 @@
+"""Generic search for unknown content in parsed API models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, cast
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_unknown import (
+    BoostyPostDataUnknownDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    BoostyUnknownValue,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownContent:
+    """A value the client doesn't know yet: where it sits and what came."""
+
+    path: str
+    raw: str
+
+
+def collect_unknown_content(model: BaseModel) -> set[UnknownContent]:
+    """
+    Find every unknown value anywhere in a parsed model tree.
+
+    Tolerant fields parse unknown input into BoostyUnknownValue and unknown
+    chunks into BoostyPostDataUnknownDTO, so one type-driven walk reports
+    them all. There is no per-field registry to keep in sync: a new tolerant
+    field is discovered automatically.
+    """
+    found: set[UnknownContent] = set()
+    _walk(model, '', found)
+    return found
+
+
+def _walk(value: object, path: str, found: set[UnknownContent]) -> None:
+    if isinstance(value, BoostyUnknownValue):
+        found.add(UnknownContent(path=path, raw=value.raw))
+        return
+    if isinstance(value, BoostyPostDataUnknownDTO):
+        found.add(UnknownContent(path=_join(path, 'type'), raw=value.type))
+        return
+    if isinstance(value, BaseModel):
+        for name, field_info in type(value).model_fields.items():
+            child_path = _join(path, field_info.alias or name)
+            _walk(getattr(value, name), child_path, found)
+        return
+    if isinstance(value, (list, tuple)):
+        items = cast('Sequence[object]', value)
+        for index, item in enumerate(items):
+            _walk(item, f'{path}[{index}]', found)
+        return
+    # Scalars (str, Enum, None, numbers) can't contain unknown content.
+
+
+def _join(path: str, name: str) -> str:
+    return f'{path}.{name}' if path else name

--- a/boosty_downloader/src/infrastructure/boosty_api/models/unknown_value.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/unknown_value.py
@@ -1,0 +1,31 @@
+"""Wrapper for API values this client doesn't know yet."""
+
+from dataclasses import dataclass
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+
+@dataclass(frozen=True, slots=True)
+class BoostyUnknownValue:
+    """
+    A value from the Boosty API this client doesn't know yet.
+
+    Keeps the raw word so the run summary can name it and the user
+    can report it. Known values live in their enums; this type marks
+    everything outside of them.
+    """
+
+    raw: str
+
+
+def _wrap_raw_value(value: object) -> object:
+    if isinstance(value, BoostyUnknownValue):
+        return value
+    return BoostyUnknownValue(raw=str(value))
+
+
+# Field-annotation form: any non-enum value is wrapped, keeping the raw word.
+# Place it LAST in a union (after the enum and None) with
+# union_mode='left_to_right', otherwise it swallows known values too.
+UnknownValue = Annotated[BoostyUnknownValue, BeforeValidator(_wrap_raw_value)]

--- a/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
@@ -1,0 +1,38 @@
+"""Render pydantic validation errors as short human-readable lines."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pydantic_core import ErrorDetails
+
+
+def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
+    """
+    Turn pydantic error details into lines like ``data[8].playerUrls[4].type: unknown value 'ondemand_dash'``.
+
+    The path style matches collect_unknown_content, so users see the same
+    addressing everywhere. Enum mismatches show the offending word instead
+    of the full list of expected values.
+    """
+    return [_format_error(error) for error in errors]
+
+
+def _format_error(error: ErrorDetails) -> str:
+    path = _format_loc(error['loc'])
+    if error['type'] == 'enum':
+        return f'{path}: unknown value {error.get("input")!r}'
+    return f'{path}: {error["msg"]}'
+
+
+def _format_loc(loc: tuple[int | str, ...]) -> str:
+    path = ''
+    for part in loc:
+        if isinstance(part, int):
+            path += f'[{part}]'
+        else:
+            path = f'{path}.{part}' if path else part
+    return path or '(root)'

--- a/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
@@ -6,12 +6,18 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from collections.abc import Set as AbstractSet
 
     from pydantic_core import ErrorDetails
 
     from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
         SkippedPost,
     )
+    from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+        UnknownContent,
+    )
+
+GITHUB_ISSUES_URL = 'https://github.com/Glitchy-Sheep/boosty-downloader/issues'
 
 
 def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
@@ -23,6 +29,38 @@ def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
     of the full list of expected values.
     """
     return [_format_error(error) for error in errors]
+
+
+def format_run_summary(
+    skipped_posts: Sequence[SkippedPost],
+    unknown_content: AbstractSet[UnknownContent],
+) -> str | None:
+    """
+    Build the final block about everything this run didn't understand.
+
+    Returns None when there is nothing to report, so clean runs stay silent.
+    """
+    if not skipped_posts and not unknown_content:
+        return None
+
+    lines = ['Some content was not understood by this version of the downloader:']
+    if skipped_posts:
+        lines.append(f' Skipped posts ({len(skipped_posts)}):')
+        for skipped in skipped_posts:
+            lines.append(f'  - "{skipped.title}" (id {skipped.post_id})')
+            lines.extend(
+                f'     - {line}' for line in format_validation_errors(skipped.errors)
+            )
+    if unknown_content:
+        lines.append(' Unknown content (downloaded around, not lost):')
+        lines.extend(
+            f'  - {item.path} = {item.raw!r}'
+            for item in sorted(unknown_content, key=lambda u: (u.path, u.raw))
+        )
+    lines.append(
+        f'Please report this at {GITHUB_ISSUES_URL} so the client can be updated.'
+    )
+    return '\n'.join(lines)
 
 
 def format_skipped_post(skipped: SkippedPost) -> str:

--- a/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
@@ -9,6 +9,10 @@ if TYPE_CHECKING:
 
     from pydantic_core import ErrorDetails
 
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+        SkippedPost,
+    )
+
 
 def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
     """
@@ -19,6 +23,17 @@ def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
     of the full list of expected values.
     """
     return [_format_error(error) for error in errors]
+
+
+def format_skipped_post(skipped: SkippedPost) -> str:
+    """One warning block for a post the client could not parse."""
+    details = '\n'.join(
+        f'   - {line}' for line in format_validation_errors(skipped.errors)
+    )
+    return (
+        f'Skipped post "{skipped.title}" (id {skipped.post_id}) - '
+        f'unexpected structure:\n{details}'
+    )
 
 
 def _format_error(error: ErrorDetails) -> str:

--- a/docs/concepts/boosty/download-flow.md
+++ b/docs/concepts/boosty/download-flow.md
@@ -1,0 +1,32 @@
+# How downloading works
+
+Boosty Downloader walks an author's blog page by page and saves every post to disk: media files plus a styled `post.html` snapshot.
+
+## The pipeline
+
+```
+CLI (typer)
+  └► use case (download all / single post)
+        └► BoostyAPIClient - paginated fetch, rate limited
+              └► PostDTO (pydantic models of the raw API answer)
+                    └► post_mapper - DTO to domain Post
+                          ├► downloads by content filters
+                          ├► post.html render (Jinja)
+                          └► cache update (SQLite)
+```
+
+1. **Fetch.** `BoostyAPIClient.iterate_over_posts` pages through `blog/{name}/post/` with a rate limiter. Each page turns into validated `PostDTO` objects.
+2. **Cache check.** A SQLite cache keeps per-post flags by content type (files, videos, audio, ...). The run skips parts it already has.
+3. **Map.** `map_post_dto_to_domain` turns API DTOs into domain chunks (text, image, video, file, audio, list). The domain layer knows nothing about Boosty shapes.
+4. **Download.** Images, files and Boosty videos go through the aiohttp downloader; external videos (YouTube, Vimeo) go through yt-dlp.
+5. **Render.** Chunks processed in this run become `post.html` via Jinja templates.
+6. **Remember.** The cache records which content types finished, so the next run downloads only what is missing.
+
+## Layers
+
+- `cli/` - typer commands and console output
+- `application/` - use cases and mappers, orchestration
+- `domain/` - pure post model, stdlib only
+- `infrastructure/` - Boosty API client, downloaders, cache, HTML generator
+
+The API contract changes without notice, so the API layer must survive unknown data - see [tolerant-reader.md](./tolerant-reader.md).

--- a/docs/concepts/boosty/tolerant-reader.md
+++ b/docs/concepts/boosty/tolerant-reader.md
@@ -1,0 +1,52 @@
+# Tolerant Reader: surviving Boosty API changes
+
+Boosty changes its API without notice: new content types, new fields and new enum values appear over time - most recently the `ondemand_*` video url types (Aug 2026). One new word from the server used to kill the whole download.
+
+This client follows the [Tolerant Reader](https://martinfowler.com/bliki/TolerantReader.html) pattern with the [RFC 9413](https://www.rfc-editor.org/rfc/rfc9413.html) amendment: **accept the unknown, lose nothing, and always tell the user**.
+
+## The invariant: unknown is a type
+
+Unknown data exists in the codebase only as two wrapper types:
+
+| Wrapper | Covers | Example |
+|---|---|---|
+| `BoostyUnknownValue(raw=...)` | a value outside a known enum | new video url type `'ondemand_dash'` |
+| `BoostyPostDataUnknownDTO` | a whole chunk of an unknown type | a new Boosty content block |
+
+Every field with a fixed set of values follows one pattern - enum plus catch-all:
+
+```python
+TolerantOkVideoType = Annotated[
+    BoostyOkVideoType | UnknownValue,
+    Field(union_mode='left_to_right'),
+]
+```
+
+- The enum is the point of truth for the known set.
+- Anything else parses into `BoostyUnknownValue`, keeping the raw word.
+- `union_mode='left_to_right'` is required: pydantic's default smart mode lets the catch-all swallow known values too. Pinned by `test_known_url_type_still_parses_exactly`.
+
+Unknown chunk types fall back the same way: the discriminated union of known chunks gets `BoostyPostDataUnknownDTO` as the last resort. Only tag errors trigger the fallback. A known chunk with a broken body still fails validation, so a real breakage never hides behind "unknown".
+
+## Observability: the generic walk
+
+`collect_unknown_content(post)` walks a parsed post and returns every wrapper it finds, with its API path:
+
+```
+data[8].playerUrls[2].type = 'ondemand_hls'
+```
+
+There is no registry of tolerant fields to keep in sync. Adding a new tolerant field takes zero extra steps:
+
+- without the wrapper an unknown value fails loudly (ValidationError) - you cannot become tolerant silently;
+- with the wrapper the walk finds it automatically.
+
+The run summary (being built now) will list the findings and ask to report them - new Boosty content becomes a GitHub issue instead of a silent loss.
+
+## Where the code lives
+
+- `infrastructure/boosty_api/models/unknown_value.py` - the value wrapper
+- `infrastructure/boosty_api/models/post/post_data_types/post_data_unknown.py` - the chunk fallback
+- `infrastructure/boosty_api/models/post/base_post_data.py` - the union with tag-only fallback
+- `infrastructure/boosty_api/models/unknown_content.py` - the generic walk
+- Tests: `test/unit/boosty_api/`, `test/unit/mappers/post_mapper_test.py`

--- a/test/unit/boosty_api/client_test.py
+++ b/test/unit/boosty_api/client_test.py
@@ -15,6 +15,7 @@ from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPINoUsernameError,
     BoostyAPIUnauthorizedError,
     BoostyAPIUnknownError,
+    BoostyAPIValidationError,
 )
 
 if TYPE_CHECKING:
@@ -129,3 +130,63 @@ async def test_200_with_valid_empty_page_returns_posts_response():
     assert response.posts == []
     assert response.extra.is_last is True
     assert response.extra.offset == ''
+
+
+VALID_POST: Any = {
+    'id': 'p1',
+    'title': 'ok post',
+    'createdAt': 1700000000,
+    'updatedAt': 1700000000,
+    'hasAccess': True,
+    'signedQuery': '',
+    'data': [],
+}
+
+
+@pytest.mark.asyncio
+async def test_broken_post_is_skipped_and_page_survives():
+    client = _make_client(
+        _FakeResponse(
+            status=200,
+            json_data={
+                'data': [VALID_POST, {'id': 'b1', 'title': 'broken'}],
+                'extra': VALID_EXTRA,
+            },
+        )
+    )
+
+    response = await client.get_author_posts('any_author', limit=2)
+
+    assert [p.id for p in response.posts] == ['p1']
+    assert len(response.skipped_posts) == 1
+    assert response.skipped_posts[0].post_id == 'b1'
+    assert response.skipped_posts[0].title == 'broken'
+    assert response.skipped_posts[0].errors
+
+
+@pytest.mark.asyncio
+async def test_page_of_only_broken_posts_returns_empty_not_error():
+    client = _make_client(
+        _FakeResponse(
+            status=200,
+            json_data={'data': [{'nope': 1}, {'nope': 2}], 'extra': VALID_EXTRA},
+        )
+    )
+
+    response = await client.get_author_posts('any_author', limit=2)
+
+    assert response.posts == []
+    assert len(response.skipped_posts) == 2
+
+
+@pytest.mark.asyncio
+async def test_broken_pagination_still_fails_the_page():
+    client = _make_client(
+        _FakeResponse(
+            status=200,
+            json_data={'data': [VALID_POST], 'extra': {'nope': 1}},
+        )
+    )
+
+    with pytest.raises(BoostyAPIValidationError):
+        await client.get_author_posts('any_author', limit=1)

--- a/test/unit/boosty_api/ok_video_types_test.py
+++ b/test/unit/boosty_api/ok_video_types_test.py
@@ -8,16 +8,23 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
     BoostyOkVideoType,
     BoostyOkVideoUrl,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    BoostyUnknownValue,
+)
 
 
 @pytest.mark.parametrize('new_type', ['ondemand_dash', 'ondemand_hls'])
-def test_unknown_url_type_parses_as_unknown(new_type: str):
-    url = BoostyOkVideoUrl.model_validate({'url': 'https://vd.example/1', 'type': new_type})
+def test_unknown_url_type_keeps_raw_word(new_type: str):
+    url = BoostyOkVideoUrl.model_validate(
+        {'url': 'https://vd.example/1', 'type': new_type}
+    )
 
-    assert url.type is BoostyOkVideoType.unknown
+    assert url.type == BoostyUnknownValue(raw=new_type)
 
 
 def test_known_url_type_still_parses_exactly():
-    url = BoostyOkVideoUrl.model_validate({'url': 'https://vd.example/1', 'type': 'medium'})
+    url = BoostyOkVideoUrl.model_validate(
+        {'url': 'https://vd.example/1', 'type': 'medium'}
+    )
 
     assert url.type is BoostyOkVideoType.medium

--- a/test/unit/boosty_api/ok_video_types_test.py
+++ b/test/unit/boosty_api/ok_video_types_test.py
@@ -1,0 +1,23 @@
+"""Regression tests for tolerant parsing of Boosty ok_video url types."""
+
+from __future__ import annotations
+
+import pytest
+
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_ok_video import (
+    BoostyOkVideoType,
+    BoostyOkVideoUrl,
+)
+
+
+@pytest.mark.parametrize('new_type', ['ondemand_dash', 'ondemand_hls'])
+def test_unknown_url_type_parses_as_unknown(new_type: str):
+    url = BoostyOkVideoUrl.model_validate({'url': 'https://vd.example/1', 'type': new_type})
+
+    assert url.type is BoostyOkVideoType.unknown
+
+
+def test_known_url_type_still_parses_exactly():
+    url = BoostyOkVideoUrl.model_validate({'url': 'https://vd.example/1', 'type': 'medium'})
+
+    assert url.type is BoostyOkVideoType.medium

--- a/test/unit/boosty_api/post_chunks_test.py
+++ b/test/unit/boosty_api/post_chunks_test.py
@@ -1,0 +1,75 @@
+"""Regression tests for tolerant parsing of unknown post chunk types."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from boosty_downloader.src.infrastructure.boosty_api.models.post.base_post_data import (
+    BasePostData,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types import (
+    BoostyPostDataListDTO,
+    BoostyPostDataTextDTO,
+    BoostyPostDataUnknownDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_list import (
+    BoostyListItemType,
+    BoostyListStyle,
+    BoostyPostDataListDataItemDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    BoostyUnknownValue,
+)
+
+CHUNK_ADAPTER: TypeAdapter[BasePostData] = TypeAdapter(BasePostData)
+
+
+def test_unknown_chunk_type_parses_as_unknown():
+    chunk = CHUNK_ADAPTER.validate_python({'type': 'super_new_thing', 'payload': 1})
+
+    assert isinstance(chunk, BoostyPostDataUnknownDTO)
+    assert chunk.type == 'super_new_thing'
+
+
+def test_known_chunk_still_parses_exactly():
+    chunk = CHUNK_ADAPTER.validate_python(
+        {'type': 'text', 'content': 'hello', 'modificator': ''}
+    )
+
+    assert isinstance(chunk, BoostyPostDataTextDTO)
+
+
+def test_known_chunk_with_broken_body_still_fails():
+    with pytest.raises(ValidationError):
+        CHUNK_ADAPTER.validate_python({'type': 'ok_video'})
+
+
+def test_new_list_style_keeps_raw_word():
+    list_chunk = BoostyPostDataListDTO.model_validate(
+        {'type': 'list', 'items': [], 'style': 'checklist'}
+    )
+
+    assert list_chunk.style == BoostyUnknownValue(raw='checklist')
+
+
+def test_known_list_style_parses_exactly():
+    list_chunk = BoostyPostDataListDTO.model_validate(
+        {'type': 'list', 'items': [], 'style': 'ordered'}
+    )
+
+    assert list_chunk.style is BoostyListStyle.ordered
+
+
+def test_absent_list_style_stays_none():
+    list_chunk = BoostyPostDataListDTO.model_validate({'type': 'list', 'items': []})
+
+    assert list_chunk.style is None
+
+
+def test_known_list_item_type_parses_exactly():
+    item = BoostyPostDataListDataItemDTO.model_validate(
+        {'type': 'text', 'content': 'hi'}
+    )
+
+    assert item.type is BoostyListItemType.text

--- a/test/unit/boosty_api/unknown_content_test.py
+++ b/test/unit/boosty_api/unknown_content_test.py
@@ -1,0 +1,38 @@
+"""Tests for the generic unknown-content walk."""
+
+from __future__ import annotations
+
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types import (
+    BoostyPostDataListDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+    collect_unknown_content,
+)
+
+
+def test_clean_tree_yields_nothing():
+    chunk = BoostyPostDataListDTO.model_validate(
+        {
+            'type': 'list',
+            'style': 'ordered',
+            'items': [{'data': [{'type': 'text', 'content': 'x'}]}],
+        }
+    )
+
+    assert collect_unknown_content(chunk) == set()
+
+
+def test_wrapper_is_found_at_any_depth():
+    chunk = BoostyPostDataListDTO.model_validate(
+        {
+            'type': 'list',
+            'items': [
+                {'items': [{'items': [{'data': [{'type': 'weird', 'content': ''}]}]}]}
+            ],
+        }
+    )
+
+    assert collect_unknown_content(chunk) == {
+        UnknownContent(path='items[0].items[0].items[0].data[0].type', raw='weird')
+    }

--- a/test/unit/boosty_api/validation_errors_test.py
+++ b/test/unit/boosty_api/validation_errors_test.py
@@ -7,7 +7,11 @@ from enum import Enum
 import pytest
 from pydantic import BaseModel, ValidationError
 
+from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+    SkippedPost,
+)
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_skipped_post,
     format_validation_errors,
 )
 
@@ -51,3 +55,17 @@ def test_nested_loc_renders_as_api_path():
     )
 
     assert lines == ["data[1].type: unknown value 'nope'"]
+
+
+def test_skipped_post_block_names_the_post_and_lists_problems():
+    block = format_skipped_post(
+        SkippedPost(
+            post_id='b1',
+            title='broken post',
+            errors=_real_errors({'data': [{'type': 'nope'}], 'title': 't'}),
+        )
+    )
+
+    assert 'broken post' in block
+    assert 'b1' in block
+    assert "data[0].type: unknown value 'nope'" in block

--- a/test/unit/boosty_api/validation_errors_test.py
+++ b/test/unit/boosty_api/validation_errors_test.py
@@ -10,7 +10,12 @@ from pydantic import BaseModel, ValidationError
 from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
     SkippedPost,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+)
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    GITHUB_ISSUES_URL,
+    format_run_summary,
     format_skipped_post,
     format_validation_errors,
 )
@@ -69,3 +74,19 @@ def test_skipped_post_block_names_the_post_and_lists_problems():
     assert 'broken post' in block
     assert 'b1' in block
     assert "data[0].type: unknown value 'nope'" in block
+
+
+def test_run_summary_lists_everything_and_asks_to_report():
+    summary = format_run_summary(
+        [SkippedPost(post_id='b1', title='broken post', errors=[])],
+        {UnknownContent(path='data[0].type', raw='novel_thing')},
+    )
+
+    assert summary is not None
+    assert 'broken post' in summary
+    assert "data[0].type = 'novel_thing'" in summary
+    assert GITHUB_ISSUES_URL in summary
+
+
+def test_run_summary_is_none_when_clean():
+    assert format_run_summary([], set()) is None

--- a/test/unit/boosty_api/validation_errors_test.py
+++ b/test/unit/boosty_api/validation_errors_test.py
@@ -1,0 +1,53 @@
+"""Regression tests for human-readable rendering of validation errors."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    format_validation_errors,
+)
+
+
+class _Color(Enum):
+    red = 'red'
+
+
+class _Inner(BaseModel):
+    type: _Color
+
+
+class _Outer(BaseModel):
+    data: list[_Inner]
+    title: str
+
+
+def _real_errors(payload: dict) -> list:
+    with pytest.raises(ValidationError) as exc_info:
+        _Outer.model_validate(payload)
+    return exc_info.value.errors()
+
+
+def test_enum_error_shows_the_offending_word():
+    lines = format_validation_errors(
+        _real_errors({'data': [{'type': 'ondemand_dash'}], 'title': 't'})
+    )
+
+    assert lines == ["data[0].type: unknown value 'ondemand_dash'"]
+
+
+def test_non_enum_error_keeps_pydantic_message():
+    lines = format_validation_errors(_real_errors({'data': []}))
+
+    assert lines == ['title: Field required']
+
+
+def test_nested_loc_renders_as_api_path():
+    lines = format_validation_errors(
+        _real_errors({'data': [{'type': 'red'}, {'type': 'nope'}], 'title': 't'})
+    )
+
+    assert lines == ["data[1].type: unknown value 'nope'"]

--- a/test/unit/download_manager/ok_video_ranking_test.py
+++ b/test/unit/download_manager/ok_video_ranking_test.py
@@ -100,3 +100,23 @@ def test_ranking_dict_with_duplicate_entries():
     assert ranking.pop_max() == ('a', 30)
     assert ranking.pop_max() == ('b', 20)
     assert ranking.pop_max() is None
+
+
+def test_known_quality_beats_unknown_type():
+    video_urls = [
+        BoostyOkVideoUrl(url='https://vd.example/unknown', type=BoostyOkVideoType.unknown),
+        BoostyOkVideoUrl(url='https://vd.example/medium', type=BoostyOkVideoType.medium),
+    ]
+
+    best_video = get_best_video(video_urls)
+
+    assert best_video is not None
+    assert best_video[1] == BoostyOkVideoType.medium
+
+
+def test_only_unknown_types_gives_none():
+    video_urls = [
+        BoostyOkVideoUrl(url='https://vd.example/unknown', type=BoostyOkVideoType.unknown),
+    ]
+
+    assert get_best_video(video_urls) is None

--- a/test/unit/download_manager/ok_video_ranking_test.py
+++ b/test/unit/download_manager/ok_video_ranking_test.py
@@ -7,6 +7,9 @@ from boosty_downloader.src.application.ok_video_ranking import (
     BoostyOkVideoUrl,
     RankingDict,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    BoostyUnknownValue,
+)
 
 
 def test_ranking_dict_basic_operations():
@@ -104,8 +107,13 @@ def test_ranking_dict_with_duplicate_entries():
 
 def test_known_quality_beats_unknown_type():
     video_urls = [
-        BoostyOkVideoUrl(url='https://vd.example/unknown', type=BoostyOkVideoType.unknown),
-        BoostyOkVideoUrl(url='https://vd.example/medium', type=BoostyOkVideoType.medium),
+        BoostyOkVideoUrl(
+            url='https://vd.example/unknown',
+            type=BoostyUnknownValue(raw='ondemand_dash'),
+        ),
+        BoostyOkVideoUrl(
+            url='https://vd.example/medium', type=BoostyOkVideoType.medium
+        ),
     ]
 
     best_video = get_best_video(video_urls)
@@ -116,7 +124,10 @@ def test_known_quality_beats_unknown_type():
 
 def test_only_unknown_types_gives_none():
     video_urls = [
-        BoostyOkVideoUrl(url='https://vd.example/unknown', type=BoostyOkVideoType.unknown),
+        BoostyOkVideoUrl(
+            url='https://vd.example/unknown',
+            type=BoostyUnknownValue(raw='ondemand_dash'),
+        ),
     ]
 
     assert get_best_video(video_urls) is None

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -9,6 +9,9 @@ from boosty_downloader.src.application.mappers.post_mapper import (
     map_post_dto_to_domain,
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
+    UnknownContent,
+)
 
 if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.base_post_data import (
@@ -17,6 +20,9 @@ if TYPE_CHECKING:
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_audio import (
     BoostyPostDataAudioDTO,
 )
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_list import (
+    BoostyPostDataListDTO,
+)
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_ok_video import (
     BoostyOkVideoType,
     BoostyOkVideoUrl,
@@ -24,6 +30,12 @@ from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_text import (
     BoostyPostDataTextDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_unknown import (
+    BoostyPostDataUnknownDTO,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import (
+    BoostyUnknownValue,
 )
 
 
@@ -146,3 +158,87 @@ def test_mixed_post_with_incomplete_video_and_complete_text():
     assert len(result.post.post_data_chunks) == 2
     assert DownloadContentTypeFilter.boosty_videos in result.incomplete_content_types
     assert DownloadContentTypeFilter.audio not in result.incomplete_content_types
+
+
+def test_unknown_chunk_is_skipped_and_counted():
+    unknown = BoostyPostDataUnknownDTO(type='super_new_thing')
+    post_dto = _make_post_dto([unknown])
+
+    result = map_post_dto_to_domain(
+        post_dto, preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert result.post.post_data_chunks == []
+    assert result.unknown_content == {
+        UnknownContent(path='data[0].type', raw='super_new_thing')
+    }
+
+
+def test_unknown_video_url_type_is_reported_not_fatal():
+    video = BoostyPostDataOkVideoDTO(
+        type='ok_video',
+        title='test video',
+        failover_host='https://example.com',
+        duration=timedelta(seconds=120),
+        upload_status='ok',
+        complete=True,
+        player_urls=[
+            BoostyOkVideoUrl(
+                type=BoostyUnknownValue(raw='ondemand_dash'), url='https://e/1'
+            ),
+            BoostyOkVideoUrl(type=BoostyOkVideoType.medium, url='https://e/2'),
+        ],
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([video]), preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 1
+    assert result.unknown_content == {
+        UnknownContent(path='data[0].playerUrls[0].type', raw='ondemand_dash')
+    }
+
+
+def test_list_with_unknown_style_keeps_its_items():
+    list_chunk = BoostyPostDataListDTO.model_validate(
+        {
+            'type': 'list',
+            'style': 'checklist',
+            'items': [{'data': [{'type': 'text', 'content': 'point one'}]}],
+        }
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([list_chunk]), preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 1
+    assert result.unknown_content == {
+        UnknownContent(path='data[0].style', raw='checklist')
+    }
+
+
+def test_non_text_list_item_is_reported_not_silent():
+    list_chunk = BoostyPostDataListDTO.model_validate(
+        {
+            'type': 'list',
+            'style': 'unordered',
+            'items': [
+                {'data': [{'type': 'text', 'content': 'point one'}]},
+                {
+                    'items': [{'data': [{'type': 'image', 'content': ''}]}],
+                    'data': [{'type': 'text', 'content': 'point two'}],
+                },
+            ],
+        }
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([list_chunk]), preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert len(result.post.post_data_chunks) == 1
+    assert result.unknown_content == {
+        UnknownContent(path='data[0].items[1].items[0].data[0].type', raw='image')
+    }

--- a/test/unit/use_cases/check_total_posts_test.py
+++ b/test/unit/use_cases/check_total_posts_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, cast
 
 import pytest
@@ -10,9 +11,16 @@ from boosty_downloader.src.application.use_cases.check_total_posts import (
     ReportTotalPostsCountUseCase,
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types import (
+    BoostyPostDataUnknownDTO,
+)
 from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
     PostsResponse,
     SkippedPost,
+)
+from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
+    GITHUB_ISSUES_URL,
 )
 
 if TYPE_CHECKING:
@@ -57,10 +65,22 @@ class _FakeApi:
         yield self._page
 
 
+def _make_post_with_unknown_chunk() -> PostDTO:
+    return PostDTO(
+        id='p1',
+        title='post with novelty',
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        has_access=True,
+        signed_query='',
+        data=[BoostyPostDataUnknownDTO(type='novel_thing')],
+    )
+
+
 @pytest.mark.asyncio
-async def test_skipped_post_becomes_a_warning():
+async def test_skipped_post_warns_inline_and_run_summary_reports_everything():
     page = PostsResponse(
-        posts=[],
+        posts=[_make_post_with_unknown_chunk()],
         extra=Extra(offset='', is_last=True),
         skipped_posts=[
             SkippedPost(
@@ -79,6 +99,9 @@ async def test_skipped_post_becomes_a_warning():
 
     await use_case.execute()
 
-    assert len(logger.warnings) == 1
-    assert 'broken post' in logger.warnings[0]
-    assert 'b1' in logger.warnings[0]
+    inline, summary = logger.warnings
+    assert 'broken post' in inline
+    assert 'b1' in inline
+    assert "data[0].type = 'novel_thing'" in summary
+    assert 'broken post' in summary
+    assert GITHUB_ISSUES_URL in summary

--- a/test/unit/use_cases/check_total_posts_test.py
+++ b/test/unit/use_cases/check_total_posts_test.py
@@ -1,0 +1,84 @@
+"""Regression test: skipped posts must reach the user as warnings."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.use_cases.check_total_posts import (
+    ReportTotalPostsCountUseCase,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
+from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+    PostsResponse,
+    SkippedPost,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+        BoostyAPIClient,
+    )
+    from boosty_downloader.src.infrastructure.loggers.logger_instances import RichLogger
+
+
+class _FakeLogger:
+    """Collects log lines instead of printing them."""
+
+    def __init__(self) -> None:
+        self.warnings: list[str] = []
+        self.other: list[str] = []
+
+    def warning(self, msg: str, **kwargs: object) -> None:
+        del kwargs
+        self.warnings.append(msg)
+
+    def info(self, msg: str, **kwargs: object) -> None:
+        del kwargs
+        self.other.append(msg)
+
+    def success(self, msg: str, **kwargs: object) -> None:
+        del kwargs
+        self.other.append(msg)
+
+
+class _FakeApi:
+    """One page with one skipped post, then stop."""
+
+    def __init__(self, page: PostsResponse) -> None:
+        self._page = page
+
+    async def iterate_over_posts(
+        self, *args: object, **kwargs: object
+    ) -> AsyncGenerator[PostsResponse, None]:
+        del args, kwargs
+        yield self._page
+
+
+@pytest.mark.asyncio
+async def test_skipped_post_becomes_a_warning():
+    page = PostsResponse(
+        posts=[],
+        extra=Extra(offset='', is_last=True),
+        skipped_posts=[
+            SkippedPost(
+                post_id='b1',
+                title='broken post',
+                errors=[],
+            )
+        ],
+    )
+    logger = _FakeLogger()
+    use_case = ReportTotalPostsCountUseCase(
+        author_name='any_author',
+        logger=cast('RichLogger', logger),
+        boosty_api=cast('BoostyAPIClient', _FakeApi(page)),
+    )
+
+    await use_case.execute()
+
+    assert len(logger.warnings) == 1
+    assert 'broken post' in logger.warnings[0]
+    assert 'b1' in logger.warnings[0]


### PR DESCRIPTION
## Summary

Boosty changes its API without notice, and one unknown word used to kill the whole download. The client now follows the Tolerant Reader pattern: unknown data is kept, skipped where needed, and reported to the user with exact paths.

## Problem

- Boosty added new `ondemand_dash` / `ondemand_hls` video url types (Aug 2026), and every `check`/`download` run died with a validation error
- One broken post failed the whole page of up to 100 posts
- Validation details printed as a raw wall of pydantic dicts
- Nothing told the user what exactly the client didn't understand, so there was nothing to report

## Fix

- Unknown data exists only as two named types: `BoostyUnknownValue(raw=...)` for values outside a known enum, `BoostyPostDataUnknownDTO` for whole chunks
- Fields with a fixed set of values use one pattern: `Enum | UnknownValue`, the enum stays the point of truth, the raw word is kept
- A known chunk with a broken body still fails validation, so real breakage is not masked as "unknown"
- Posts validate one by one: a broken post becomes a warning with its title, id and problems, the rest of the page downloads
- One generic walk (`collect_unknown_content`) finds every unknown in a parsed post as an API path, with no registry to keep in sync
- `check` and `download` end with a summary of everything not understood, asking to report it at GitHub issues
- `download --post-url` says the real reason when the target post itself can't be parsed - it used to end with a misleading "not found"
- New docs: `docs/concepts/boosty/` (download flow + Tolerant Reader)

## Before / After

**Before:** `check -u <author>` on a blog with one new video url type crashed with a wall of pydantic error dicts.

**After:** the run finishes and ends with:

```
Some content was not understood by this version of the downloader:
 Unknown content (downloaded around, not lost):
  - data[8].playerUrls[2].type = 'ondemand_dash'
  - data[8].playerUrls[8].type = 'ondemand_hls'
Please report this at https://github.com/Glitchy-Sheep/boosty-downloader/issues so the client can be updated.
```

## Tests

- `test_unknown_url_type_keeps_raw_word`, `test_known_url_type_still_parses_exactly` - tolerant enum parsing, and the catch-all never swallows known values
- `test_unknown_chunk_type_parses_as_unknown`, `test_known_chunk_with_broken_body_still_fails` - chunk fallback triggers on unknown tags only
- `test_wrapper_is_found_at_any_depth`, `test_clean_tree_yields_nothing` - the generic walk
- `test_broken_post_is_skipped_and_page_survives`, `test_broken_pagination_still_fails_the_page` - per-post validation boundaries
- `test_enum_error_shows_the_offending_word`, `test_nested_loc_renders_as_api_path` - readable validation errors
- `test_skipped_post_warns_inline_and_run_summary_reports_everything`, `test_run_summary_is_none_when_clean` - the final summary
- Checked live against the real API: `check` and `download` on a blog with the new video url types finish and print the summary above

## Notes

- The searched-post-is-broken path in `download --post-url` and clean-run silence are covered by tests; the incident blog itself was the live testbed
