### PR TITLE
[ci] Split CI into four parallel jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,33 @@
+name: Setup Python & Poetry
+description: Python, Poetry and a cached in-project virtualenv
+
+inputs:
+  python-version:
+    description: Python version to set up
+    default: '3.12'
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      id: python
+      uses: actions/setup-python@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-in-project: true
+
+    # The whole in-project .venv is cached, keyed by the lockfile:
+    # on a cache hit `poetry sync` is a fast no-op instead of a reinstall.
+    - name: Cache virtualenv
+      uses: actions/cache@v6
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-py${{ steps.python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
+
+    - name: Install dependencies
+      run: poetry sync --no-interaction
+      shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,44 +4,43 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, labeled]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# A new push to a PR cancels its previous run; runs on main are never cancelled.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  check:
-    name: 🧪 Lint, Test & Build
+  quality:
+    name: 🩺 Lint & Types
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      # fetch-depth: 0 is needed for the CHANGELOG diff check to find
-      # the merge base between the PR branch and main.
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup environment
+        uses: ./.github/actions/setup
+      - name: Ruff check
+        run: make lint-check
+      - name: Ruff format
+        run: make format-check
+      - name: Pyright
+        run: make types
 
-      # Speed up repeated CI runs by caching downloaded pip packages.
-      # The cache key is derived from poetry.lock, so it invalidates
-      # automatically when dependencies change.
-      - name: Set up Python & Poetry
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: 'pip'
-          cache-dependency-path: '**/poetry.lock'
-
-      # virtualenvs-in-project creates .venv inside the repo directory.
-      # This is required for the pip cache above to work correctly -
-      # otherwise Poetry places the venv in a global path that isn't cached.
-      - uses: snok/install-poetry@v1
-        with:
-          virtualenvs-in-project: true
-
-      - name: Install dependencies
-        run: poetry sync
-
-      - name: Code quality checks
-        run: |
-          make lint-check
-          make format-check
-          make types
-
+  test:
+    name: 🧪 Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup environment
+        uses: ./.github/actions/setup
       # Integration tests need Boosty API credentials stored in test/integration/.env.
       # Fork PRs won't have this file (it's gitignored and contains secrets),
       # so we check if it exists before running. This prevents confusing
@@ -56,6 +55,34 @@ jobs:
           fi
         timeout-minutes: 5
 
+  build:
+    name: 📦 Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup environment
+        uses: ./.github/actions/setup
+      - name: Build & verify
+        run: |
+          make build
+          ls dist/*.whl dist/*.tar.gz || { echo "❌ Build artifacts missing"; exit 1; }
+          echo "✅ Build artifacts created successfully"
+
+  changelog:
+    name: 📝 Changelog
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Full history is needed to diff the Unreleased section
+      # against the merge base between the PR branch and main.
+      - name: Checkout (full history)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
       # Enforce that every PR adds new entries to the "## Unreleased" section
       # in CHANGELOG.md. Simply touching the file is not enough - the check
       # verifies that the Unreleased section gained new lines compared to the
@@ -65,7 +92,6 @@ jobs:
       #   - Put [skip changelog] anywhere in the PR title, OR
       #   - Add the "ci/skip-changelog" label to the PR
       - name: Check CHANGELOG.md updated
-        if: github.event_name == 'pull_request'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
@@ -125,9 +151,3 @@ jobs:
             echo ""
             echo "$ADDED"
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Build & verify
-        run: |
-          make build
-          ls dist/*.whl dist/*.tar.gz || { echo "❌ Build artifacts missing"; exit 1; }
-          echo "✅ Build artifacts created successfully"


### PR DESCRIPTION
## Summary

One serial job becomes four parallel ones: lint, tests, build and the changelog gate now report independently, and pushes to main finally run CI at all.

## Problem

- A failed lint hid the test results: one problem per push, slow feedback loop
- One opaque check meant the branch ruleset could not require tests separately
- The single job was not ready for the Python/OS matrix planned in the roadmap
- Merged main lived without any CI: the workflow only ran on pull requests
- The pip cache never prevented reinstalls - Poetry rebuilt the virtualenv every run

## Fix

- Jobs `🩺 Lint & Types`, `🧪 Tests`, `📦 Build` and `📝 Changelog` run in parallel; the gate script is unchanged, and only it fetches full history - the rest get a fast shallow clone
- A composite action (`.github/actions/setup`) describes Python + Poetry once and caches the whole in-project `.venv` by the `poetry.lock` hash
- A new push to a PR cancels its stale run; runs on main are never cancelled
- `permissions: contents: read`, a timeout on every job, and a human name on every step so the run view reads as a story
- Action versions checked against the latest releases: checkout v7, setup-python v7, cache v6, install-poetry v1

## Before / After

**Before:** one check, wall time is the sum of all steps, red lint means no test signal.

**After:** four independent checks in one push, wall time is the slowest job, and the `test` job takes the roadmap matrix without re-running lint per cell.

## Tests

- This PR's own run is the live check: four separate jobs must appear and pass
- The changelog gate keeps both bypasses ([skip changelog] title marker and the `ci/skip-changelog` label) - Renovate PRs stay unblocked

## Notes

- The Python/OS matrix itself is a separate roadmap decision (stage 6); the `test` job is just ready for it
- Required status checks in the "Main Protection" ruleset can now point at the four jobs - a repo-settings follow-up
