### PR TITLE
[build] Add make setup for first-time dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test posts-example release help
+.PHONY: build test posts-example release help setup
 
 # Ensure that all the pipe-like commands work correctly.
 export PYTHONIOENCODING = utf-8
@@ -9,6 +9,7 @@ help:
 	@echo '  Boosty Downloader - Development Commands'
 	@echo ''
 	@echo '  🚀 Quick start:'
+	@echo '    make setup                                   first-time dev setup (venv + deps + editor)'
 	@echo '    make deps                                    install dependencies'
 	@echo '    poetry run python -m boosty_downloader.main  run locally'
 	@echo ''
@@ -46,6 +47,21 @@ help:
 
 deps:
 	poetry sync --no-interaction
+
+# First-time developer setup: the venv lives inside the project (./.venv),
+# so editors and CI resolve the same interpreter path. Generates VS Code
+# settings pointing at it - the file is gitignored, hence generated here.
+setup:
+	poetry config virtualenvs.in-project true --local
+	poetry sync --no-interaction
+	@mkdir -p .vscode
+	@if [ -f .vscode/settings.json ]; then \
+		echo '.vscode/settings.json exists - check python.defaultInterpreterPath points to .venv'; \
+	else \
+		printf '{\n    "python.defaultInterpreterPath": "$${workspaceFolder}/.venv/bin/python"\n}\n' > .vscode/settings.json; \
+		echo 'Created .vscode/settings.json'; \
+	fi
+	@echo 'Done. In VS Code: "Python: Select Interpreter" -> ./.venv/bin/python'
 
 build:
 	poetry build --no-cache


### PR DESCRIPTION
## Summary

One command gets a fresh clone ready: the venv lands inside the project, dependencies install, and VS Code gets interpreter settings. No more "Import could not be resolved" on a new machine.

## Problem

- A fresh clone got its venv in the global poetry cache, so editors pointed at a wrong or empty interpreter
- Pylance painted every third-party import red while the code ran fine from the terminal
- `.vscode/settings.json` is gitignored, so the fix could not be shared by committing it

## Fix

- `make setup` runs `poetry config virtualenvs.in-project true --local`, installs dependencies and generates `.vscode/settings.json` with `python.defaultInterpreterPath` pointing at `./.venv`
- An existing settings file is never overwritten - the target only prints what to check
- The target is listed first in `make help` under Quick start

## Tests

- Ran both paths by hand: with an existing settings file (untouched, hint printed) and without one (file generated, `${workspaceFolder}` survives the Makefile escaping)
