### PR TITLE
[cli] clean-cache tells the truth when there is no cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix confusing "Unknown error" for a wrong username: clear "author not found" message and a hint about the blog name (#94)
 - Survive unknown Boosty content: new types and values are kept, skipped where needed, and listed in a final summary with exact paths instead of crashing the whole download
 - Broken posts no longer fail the whole page: they are skipped with a readable warning, and validation errors are shown as short lines instead of raw dumps
+- clean-cache says when there was no cache to clean instead of reporting a false success
 
 ## 3.0.0
 

--- a/boosty_downloader/src/cli/commands/clean_cache.py
+++ b/boosty_downloader/src/cli/commands/clean_cache.py
@@ -3,6 +3,7 @@
 # pyright: reportUnusedFunction=false
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from boosty_downloader.src.cli.cli_options import (
@@ -34,11 +35,28 @@ def _clean_cache(
         or config.downloading_settings.target_directory
     )
 
+    # Opening SQLitePostCache creates the database, so a missing cache
+    # must be answered before that - otherwise the command fabricates
+    # an empty cache and reports a false success.
+    cache_db = cache_dir.absolute() / username / SQLitePostCache.DEFAULT_CACHE_FILENAME
+    if not cache_db.exists():
+        logger_instances.downloader_logger.info(
+            f'No cache found for {username} - nothing to clean'
+        )
+        return
+
     with SQLitePostCache(
         destination=cache_dir.absolute() / username,
         logger=logger_instances.downloader_logger,
     ) as post_cache:
         post_cache.remove_cache_completely()
+
+    # remove_cache_completely recreates an empty database right away;
+    # drop it so a repeated clean honestly says there is nothing to clean.
+    cache_db.unlink(missing_ok=True)
+    with suppress(OSError):
+        # Keep the folder when it still holds downloaded posts.
+        cache_db.parent.rmdir()
 
     logger_instances.downloader_logger.success(
         f'Cache for {username} has been cleaned successfully'


### PR DESCRIPTION
## Summary

`clean-cache` reported "cleaned successfully" for authors that never had a cache - a typo in the username looked like a successful clean. Now the command says what actually happened.

## Problem

- Opening the cache creates its database, so cleaning a nonexistent cache fabricated an empty one and reported success
- Removing the cache recreated an empty database right away, so a repeated clean was "successful" forever
- The user could not tell a typo from a real clean

## Fix

- A missing cache file is answered before touching the database: "No cache found for <name> - nothing to clean"
- After a real clean the leftover empty database is removed, so a repeated clean also says there is nothing to do
- The author folder is removed only when empty - downloaded posts stay in place

## Before / After

**Before:** `clean-cache -u glitchy-sheep` (typo, no such cache) -> "Cache for glitchy-sheep has been cleaned successfully".

**After:** the same command -> "No cache found for glitchy-sheep - nothing to clean".

## Tests

- Checked live in all three scenarios: nonexistent name, existing cache (file really disappears), repeated clean
- Downloaded posts survive the clean: the folder is kept when it holds anything
