### PR TITLE
[ci] Fix GitHub Release step breaking on quotes in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,14 +110,14 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
+      # Notes travel through a file: inlined into the script, any quote
+      # character in the changelog breaks the shell (it did on v3.1.0).
       - name: Extract changelog for version
-        id: changelog
         run: |
           VERSION="${{ needs.validate.outputs.version }}"
-          BODY=$(sed -n "/^## $VERSION/,/^## /{/^## $VERSION/d;/^## /d;p}" CHANGELOG.md)
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$BODY" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          sed -n "/^## $VERSION/,/^## /{/^## $VERSION/d;/^## /d;p}" CHANGELOG.md > release-notes.md
+          echo "Release notes:"
+          cat release-notes.md
 
       - name: Create GitHub Release
         env:
@@ -126,4 +126,4 @@ jobs:
           VERSION="${{ needs.validate.outputs.version }}"
           gh release create "v$VERSION" dist/* \
             --title "v$VERSION" \
-            --notes "${{ steps.changelog.outputs.body }}"
+            --notes-file release-notes.md


### PR DESCRIPTION
## Summary

The v3.1.0 release published the package to PyPI but failed at the last step - creating the GitHub Release page. This PR makes that step survive any changelog content.

## Problem

- The `Create GitHub Release` step pasted the changelog into the shell script through `${{ steps.changelog.outputs.body }}`
- GitHub Actions expands `${{ }}` as plain text before bash parses the script
- The v3.1.0 notes contain double quotes (`clear "Missing option" error`), so the first quote closed the `--notes "..."` string
- The rest of the notes became stray arguments, `gh release create` read them as asset paths and failed with `no matches found`
- Earlier releases passed only because their notes had no quotes

## Fix

- The extract step now writes the changelog section to `release-notes.md` and prints it into the job log
- `gh release create` reads it with `--notes-file`
- No changelog text is pasted into the script anymore, so no character in it can break the shell

## Before / After

**Before:** a release fails at the last step when the changelog contains a double quote.
**After:** any changelog content ships as release notes unchanged.

## Verification

- The v3.1.0 GitHub Release was created manually with the same `--notes-file` approach and the same quoted notes - worked on the first try
