### PR TITLE
[docs] Update contributor guides to the Taskfile commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,16 +13,17 @@ Thanks for your interest in contributing! This guide will help you get started. 
 ## 🔧 Getting Started
 
 1. Fork and clone the repository
-2. Install dependencies:
+2. Install the [Task](https://taskfile.dev) runner - per-OS commands are in [Dev Tools](docs/development/01-dev-tools.md)
+3. Set up the environment (in-project venv + dependencies + editor settings):
    ```bash
-   make deps
+   task setup
    ```
-3. Run the project locally:
+4. Run the project locally:
    ```bash
    poetry run python -m boosty_downloader.main
    ```
 
-All available commands are listed via `make help`.
+All available commands are listed via bare `task`.
 
 ## 👩‍💻 Making Changes
 
@@ -47,9 +48,10 @@ CI verifies that new lines were **added** to the `## Unreleased` section - simpl
 ## 🩺 Code Quality
 
 ```bash
-make ci-check    # Run all checks (lint + types + format)
-make test        # Run unit tests
-make dev-fix     # Auto-fix lint and formatting issues
+task check    # Run all checks (lint + format + types)
+task test     # Run unit tests
+task fix      # Auto-fix lint and formatting, then type check
+task ci       # Everything CI runs: checks + tests + build
 ```
 
 The project uses:
@@ -72,25 +74,16 @@ Describe not only **what** changed, but **why**.
 ## 🚀 Releasing (Maintainers)
 
 1. Make sure `## Unreleased` in CHANGELOG.md has all changes listed
-2. Run:
+2. Run the release wizard:
    ```bash
-   make release v=patch   # 2.1.2 -> 2.1.3
-   make release v=minor   # 2.1.2 -> 2.2.0
-   make release v=major   # 2.1.2 -> 3.0.0
-   make release v=2.2.0   # explicit version
+   task release -- patch   # or: minor / major / X.Y.Z
    ```
-3. Review the diff, stage and commit:
+   It checks the tools and the repo invariants, shows a preview and - after your confirmation - bumps the version, promotes the changelog, pushes the release branch and opens the release PR.
+3. Merge the release PR.
+4. Tag from fresh main:
    ```bash
-   git diff
-   git add pyproject.toml CHANGELOG.md
-   git commit -m "chore: release vX.Y.Z"
-   ```
-4. Tag and push:
-   ```bash
-   git tag vX.Y.Z
-   git push && git push origin vX.Y.Z
+   git checkout main
+   task release:tag
    ```
 
-The release workflow will automatically publish to PyPI and create a GitHub Release.
-
-The script validates that the new version is higher than the current one, the `## Unreleased` section exists and is not empty, and prevents releasing the same version twice.
+The tag triggers the release workflow: build -> PyPI -> GitHub Release. The full flow with every check explained: [Releasing](docs/development/04-releasing.md).

--- a/docs/development/04-releasing.md
+++ b/docs/development/04-releasing.md
@@ -6,7 +6,9 @@ One release = one PR with the version bump, then a tag on main. The tag triggers
 
 ### 1. Check the changelog
 
-`## Unreleased` in `CHANGELOG.md` must list everything for this release - these lines become the GitHub Release notes.
+`## Unreleased` in `CHANGELOG.md` must list everything for this release - these lines become the GitHub Release notes, word for word.
+
+The section fills up during development: the 📝 Changelog CI job requires every PR to add its entries (infra PRs skip it with the `ci/skip-changelog` label). Write entries about the effect for the user, not the mechanics, and group them under `### Added` / `### Fixed` / `### Security` - the grouping survives all the way to the release page.
 
 ### 2. Run the wizard
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -22,7 +22,10 @@ boosty_downloader/
     infrastructure/          # API client, caching, HTML rendering, yt-dlp
     cli/                     # Typer CLI options, progress reporter
 scripts/
-  release.py                 # Release automation script
+  release.py                 # Release wizard (bump, changelog, PR, tag)
+  api_preflight.py           # Credentials check before integration tests
+  posts_example.py           # Dev helper: dump posts JSON
+  build_install.py           # Build the wheel and install it via pipx
 test/
   unit/                      # Fast tests, no network
   integration/               # API tests, require .env credentials

--- a/test/ABOUT_TESTING.md
+++ b/test/ABOUT_TESTING.md
@@ -4,13 +4,11 @@ Tests structure doesn't mirror the application structure, but rather groups test
 
 ```
 test/
-├── analysis     - Tests ONLY for purpose to analyze responses by known endpoints
+├── unit         - Unit tests for the application, grouped by "domains"
 │   └── ...
 │ 
-├── unit         - Unit tests for the application, groupped by "domains"
-│   └── ...
-│ 
-└── integration  - Integration tests for the application, groupped by "domains"
+└── integration  - Integration tests against the live Boosty API, grouped by "domains"
+    └── analysis - Dumps for exploring known endpoints
 ```
 
 # Add a new test 
@@ -24,5 +22,5 @@ test/
 3. *Create test file, following the naming convention `<filename>_test.py`.*
 4. Test some functionality with `test_<functionality>` function name.
     - Use `assert` statements to check expected outcomes.
-5. *Run the test using `make test` for unit tests or `make test-integration` for integration tests.*
+5. *Run the test using `task test` for unit tests or `task test:api` for integration tests (they need `./.env`, see [Testing](../docs/development/02-testing.md)).*
 6. *Make a pull request with your changes.* (see [CONTRIBUTING.md](../CONTRIBUTING.md) for more details)


### PR DESCRIPTION
## Summary

After the Makefile -> Taskfile move (#123), three guides still taught `make` commands that no longer exist - a new contributor following them hits "command not found" on the first step. This PR brings every instruction back in line with reality.

What changed:

- `CONTRIBUTING.md`: onboarding via `task setup`, quality checks via `task check` / `test` / `fix` / `ci`, releasing via the two-step wizard (`task release -- patch`, then `task release:tag`)
- `test/ABOUT_TESTING.md`: the test tree now matches the real layout (`analysis/` lives under `integration/`), run commands are `task test` / `task test:api`
- `docs/development/README.md`: `scripts/` lists the current helpers (release wizard, api preflight, posts example, build install)
- `docs/development/04-releasing.md`: explains how `## Unreleased` fills up during development and becomes the GitHub Release notes word for word
