### PR TITLE
[downloader] Survive broken posts and stop early on failure streaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- `--skip-all-failures` flag: skip failed posts without limit instead of stopping after 5 failures in a row
+
 ### Fixed
 
 - One broken post no longer kills the whole download: it is skipped into failed_downloads.log and the run summary, and 5 failures in a row stop the run early with a resume hint (#88)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- One broken post no longer kills the whole download: it is skipped into failed_downloads.log and the run summary, and 5 failures in a row stop the run early with a resume hint (#88)
+
 ## 3.1.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The post content itself is saved in html with a little bit of styling.
       - [Option 2 - With helper script](#option-2---with-helper-script)
     - [Step 2: Paste the cookie and auth header into the config file](#step-2-paste-the-cookie-and-auth-header-into-the-config-file)
     - [Step 3: Run the utility](#step-3-run-the-utility)
+  - [🛡️ When downloads fail](#️-when-downloads-fail)
   - [💖 Contributing](#-contributing)
   - [📜 License](#-license)
 
@@ -115,6 +116,18 @@ Now you can just download your content with the following command:
 ```bash
 boosty-downloader download --username YOUR_CREATOR_NAME
 ```
+
+## 🛡️ When downloads fail
+
+One bad post never costs you the whole run:
+
+- A post that fails to download is skipped, and the run continues.
+- Every skipped post is written to `failed_downloads.log` next to your downloads.
+- At the end, a summary lists everything that was skipped and why.
+- If 5 posts in a row fail, the downloader stops early: a streak like this means the problem is not in the posts - check your disk, folder permissions, or network.
+- Prefer to finish the pass no matter what? Add `--skip-all-failures` - the run never stops on a failure streak.
+
+Downloaded posts are cached. After you fix the cause, run the same command again - finished posts are skipped in seconds, and the download continues where it stopped.
 
 ## 💖 Contributing
 

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
 
 from boosty_downloader.src.application.exceptions.application_errors import (
     ApplicationCancelledError,
+    ApplicationTooManyFailuresError,
 )
 from boosty_downloader.src.cli.commands import (
     check,
@@ -90,6 +91,11 @@ def entry_point() -> None:
     except ApplicationCancelledError:
         logger_instances.downloader_logger.warning(
             'Download cancelled by user, see you later! 💘\n'
+        )
+    except ApplicationTooManyFailuresError as e:
+        logger_instances.downloader_logger.error(
+            f'Download stopped after {e.streak} failed posts in a row - '
+            'fix the cause and run the command again to resume.'
         )
     except ClientConnectorDNSError:
         logger_instances.downloader_logger.error(

--- a/boosty_downloader/src/application/exceptions/application_errors.py
+++ b/boosty_downloader/src/application/exceptions/application_errors.py
@@ -52,3 +52,16 @@ class ApplicationCancelledError(ApplicationBaseDownloadError):
 
     Typically stops the entire download process.
     """
+
+
+class ApplicationTooManyFailuresError(Exception):
+    """
+    Raised when the full-download run stops on an unbroken failure streak.
+
+    The streak points at a systemic cause (disk, permissions, network),
+    not at individual posts; the use case reports the details before raising.
+    """
+
+    def __init__(self, streak: int) -> None:
+        super().__init__()
+        self.streak = streak

--- a/boosty_downloader/src/application/failure_streak.py
+++ b/boosty_downloader/src/application/failure_streak.py
@@ -1,0 +1,27 @@
+"""Failure-streak circuit breaker for the full-download run."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class FailureStreakBreaker:
+    """
+    Trip when post failures come in an unbroken streak.
+
+    Scattered failures are per-post problems and only cost a skip each.
+    An unbroken streak means the world around the run is broken (disk,
+    permissions, network) - going on would grind for hours downloading
+    nothing. Any success resets the streak.
+    """
+
+    threshold: int
+    _streak: int = 0
+
+    def record_success(self) -> None:
+        """Reset the streak - a success proves the run is healthy."""
+        self._streak = 0
+
+    def record_failure(self) -> bool:
+        """Count a failed post; True means the threshold is reached."""
+        self._streak += 1
+        return self._streak >= self.threshold

--- a/boosty_downloader/src/application/failure_streak.py
+++ b/boosty_downloader/src/application/failure_streak.py
@@ -12,9 +12,12 @@ class FailureStreakBreaker:
     An unbroken streak means the world around the run is broken (disk,
     permissions, network) - going on would grind for hours downloading
     nothing. Any success resets the streak.
+
+    A None threshold disables the breaker: failures are counted
+    but the run is never stopped.
     """
 
-    threshold: int
+    threshold: int | None
     _streak: int = 0
 
     def record_success(self) -> None:
@@ -24,4 +27,6 @@ class FailureStreakBreaker:
     def record_failure(self) -> bool:
         """Count a failed post; True means the threshold is reached."""
         self._streak += 1
+        if self.threshold is None:
+            return False
         return self._streak >= self.threshold

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -1,6 +1,7 @@
 """Implements the use case for downloading all posts from a Boosty author, applying filters and caching as needed."""
 
 import asyncio
+from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -8,7 +9,9 @@ from boosty_downloader.src.application.di.download_context import DownloadContex
 from boosty_downloader.src.application.exceptions.application_errors import (
     ApplicationCancelledError,
     ApplicationFailedDownloadError,
+    ApplicationTooManyFailuresError,
 )
+from boosty_downloader.src.application.failure_streak import FailureStreakBreaker
 from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
 )
@@ -25,11 +28,23 @@ from boosty_downloader.src.infrastructure.path_sanitizer import (
     sanitize_string,
 )
 
+# Failures of posts in a row, without a single success in between.
+# Scattered failures are per-post problems; a streak like this almost
+# always means a systemic cause - the run stops instead of grinding.
+CONSECUTIVE_FAILURES_LIMIT = 5
+
 if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
         PostsResponse,
         SkippedPost,
     )
+
+
+class _PostOutcome(Enum):
+    """Outcome of one post within the full-download run."""
+
+    downloaded = auto()
+    failed = auto()
 
 
 class DownloadAllPostUseCase:
@@ -68,14 +83,104 @@ class DownloadAllPostUseCase:
         for skipped in page.skipped_posts:
             self.context.progress_reporter.warn(format_skipped_post(skipped))
 
+    async def _download_one_post(
+        self,
+        single_post_use_case: DownloadSinglePostUseCase,
+        *,
+        full_post_title: str,
+        post_id: str,
+        failed_posts: list[str],
+    ) -> _PostOutcome:
+        """Run the per-post retry policy; every exit path is an explicit outcome."""
+        max_attempts = 5
+        delay = 1.0
+        for attempt in range(1, max_attempts + 1):
+            try:
+                await single_post_use_case.execute()
+            except ApplicationCancelledError:  # noqa: PERF203 - per-post isolation is the point here
+                raise
+            except ApplicationFailedDownloadError as e:
+                if attempt == max_attempts:
+                    return self._skip_after_retries(
+                        full_post_title, failed_posts, e, attempts=attempt
+                    )
+                delay = await self._wait_before_retry(
+                    full_post_title, e, attempt=attempt, delay=delay
+                )
+            # Containment: an unexpected error (e.g. OSError from a too
+            # long post title) skips this post, never the whole run.
+            # Must stay below the cancellation re-raise, or Ctrl+C
+            # would be swallowed here.
+            except Exception as e:  # noqa: BLE001
+                return await self._skip_unexpected(
+                    full_post_title, post_id, failed_posts, e
+                )
+            else:
+                return _PostOutcome.downloaded
+        return _PostOutcome.failed
+
+    def _skip_after_retries(
+        self,
+        full_post_title: str,
+        failed_posts: list[str],
+        error: ApplicationFailedDownloadError,
+        *,
+        attempts: int,
+    ) -> _PostOutcome:
+        """Give up on a post whose known failure survived all retries."""
+        failed_posts.append(f'{full_post_title} ({error.message})')
+        self.context.progress_reporter.error(
+            f'Skip post after {attempts} failed attempts: {full_post_title} ({error.message})'
+        )
+        return _PostOutcome.failed
+
+    async def _skip_unexpected(
+        self,
+        full_post_title: str,
+        post_id: str,
+        failed_posts: list[str],
+        error: Exception,
+    ) -> _PostOutcome:
+        """Give up on a post immediately: unexpected errors do not heal by retrying."""
+        failed_posts.append(f'{full_post_title} ({error})')
+        self.context.progress_reporter.error(
+            f'Skip post after unexpected error: {full_post_title} ({error})'
+        )
+        await self.context.failed_logger.add_error(
+            post_id,
+            f'Unexpected error: {error}',
+        )
+        return _PostOutcome.failed
+
+    async def _wait_before_retry(
+        self,
+        full_post_title: str,
+        error: ApplicationFailedDownloadError,
+        *,
+        attempt: int,
+        delay: float,
+    ) -> float:
+        """Report the failed attempt, back off, and return the next delay."""
+        self.context.progress_reporter.warn(
+            f'Attempt {attempt} failed for post: {full_post_title} ({error.message}), RESOURCE: ({error.resource})'
+        )
+        self.context.progress_reporter.warn(
+            f'Retrying in {delay:.1f}s... ({error.message})'
+        )
+        await asyncio.sleep(delay)
+        return min(delay * 1.5, 10.0)
+
     async def execute(self) -> None:
         posts_iterator = self.boosty_api.iterate_over_posts(
             author_name=self.author_name
         )
 
         current_page = 0
+        processed_ok = 0
         all_skipped: list[SkippedPost] = []
+        failed_posts: list[str] = []
         unknown_content: set[UnknownContent] = set()
+        breaker = FailureStreakBreaker(threshold=CONSECUTIVE_FAILURES_LIMIT)
 
         async for page in posts_iterator:
             count = len(page.posts)
@@ -119,34 +224,45 @@ class DownloadAllPostUseCase:
                     description=f'Processing page [bold]{current_page}[/bold]',
                 )
 
-                max_attempts = 5
-                delay = 1.0
-                for attempt in range(1, max_attempts + 1):
-                    try:
-                        await single_post_use_case.execute()
-                        break
-                    except ApplicationCancelledError:
-                        raise
-                    except ApplicationFailedDownloadError as e:
-                        if attempt == max_attempts:
-                            self.context.progress_reporter.error(
-                                f'Skip post after {attempt} failed attempts: {full_post_title} ({e.message})'
-                            )
-                        else:
-                            self.context.progress_reporter.warn(
-                                f'Attempt {attempt} failed for post: {full_post_title} ({e.message}), RESOURCE: ({e.resource})'
-                            )
-                            self.context.progress_reporter.warn(
-                                f'Retrying in {delay:.1f}s... ({e.message})'
-                            )
-                            await asyncio.sleep(delay)
-                            delay = min(delay * 1.5, 10.0)
+                outcome = await self._download_one_post(
+                    single_post_use_case,
+                    full_post_title=full_post_title,
+                    post_id=post_dto.id,
+                    failed_posts=failed_posts,
+                )
+                if outcome is _PostOutcome.downloaded:
+                    processed_ok += 1
+                    breaker.record_success()
+                elif breaker.record_failure():
+                    self._report_systemic_stop(processed_ok)
+                    self._print_run_summary(all_skipped, unknown_content)
+                    raise ApplicationTooManyFailuresError(
+                        streak=CONSECUTIVE_FAILURES_LIMIT
+                    )
 
             self.context.progress_reporter.complete_task(page_task_id)
             self.context.progress_reporter.success(
                 f'--- Finished page {current_page} ---'
             )
 
+        self._print_run_summary(all_skipped, unknown_content)
+
+    def _report_systemic_stop(self, processed_ok: int) -> None:
+        self.context.progress_reporter.error(
+            f'Stopped: {CONSECUTIVE_FAILURES_LIMIT} posts in a row failed - '
+            'the cause looks systemic (disk, permissions, network), '
+            'not post-specific.\n'
+            f'Posts processed before stopping: {processed_ok}. '
+            'Details: failed_downloads.log\n'
+            'Fix the cause and run the same command again - '
+            'downloaded posts are cached and will be skipped in seconds.'
+        )
+
+    def _print_run_summary(
+        self,
+        all_skipped: 'list[SkippedPost]',
+        unknown_content: set[UnknownContent],
+    ) -> None:
         summary = format_run_summary(all_skipped, unknown_content)
         if summary:
             self.context.progress_reporter.warn(summary)

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -235,7 +235,7 @@ class DownloadAllPostUseCase:
                     breaker.record_success()
                 elif breaker.record_failure():
                     self._report_systemic_stop(processed_ok)
-                    self._print_run_summary(all_skipped, unknown_content)
+                    self._print_run_summary(all_skipped, unknown_content, failed_posts)
                     raise ApplicationTooManyFailuresError(
                         streak=CONSECUTIVE_FAILURES_LIMIT
                     )
@@ -245,7 +245,7 @@ class DownloadAllPostUseCase:
                 f'--- Finished page {current_page} ---'
             )
 
-        self._print_run_summary(all_skipped, unknown_content)
+        self._print_run_summary(all_skipped, unknown_content, failed_posts)
 
     def _report_systemic_stop(self, processed_ok: int) -> None:
         self.context.progress_reporter.error(
@@ -262,7 +262,8 @@ class DownloadAllPostUseCase:
         self,
         all_skipped: 'list[SkippedPost]',
         unknown_content: set[UnknownContent],
+        failed_posts: list[str],
     ) -> None:
-        summary = format_run_summary(all_skipped, unknown_content)
+        summary = format_run_summary(all_skipped, unknown_content, failed_posts)
         if summary:
             self.context.progress_reporter.warn(summary)

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -63,12 +63,15 @@ class DownloadAllPostUseCase:
         boosty_api: BoostyAPIClient,
         destination: Path,
         download_context: DownloadContext,
+        *,
+        skip_all_failures: bool = False,
     ) -> None:
         self.author_name = author_name
 
         self.boosty_api = boosty_api
         self.destination = destination
         self.context = download_context
+        self.skip_all_failures = skip_all_failures
 
     def _note_page_anomalies(
         self,
@@ -180,7 +183,11 @@ class DownloadAllPostUseCase:
         all_skipped: list[SkippedPost] = []
         failed_posts: list[str] = []
         unknown_content: set[UnknownContent] = set()
-        breaker = FailureStreakBreaker(threshold=CONSECUTIVE_FAILURES_LIMIT)
+        # --skip-all-failures turns the breaker off: posts keep skipping
+        # without limit, the run always reaches the end.
+        breaker = FailureStreakBreaker(
+            threshold=None if self.skip_all_failures else CONSECUTIVE_FAILURES_LIMIT
+        )
 
         async for page in posts_iterator:
             count = len(page.posts)

--- a/boosty_downloader/src/cli/cli_options.py
+++ b/boosty_downloader/src/cli/cli_options.py
@@ -94,3 +94,14 @@ CacheDirectoryOption = Annotated[
         show_default=False,
     ),
 ]
+
+
+SkipAllFailuresOption = Annotated[
+    bool,
+    typer.Option(
+        '--skip-all-failures',
+        help='Skip failed posts without limit '
+        'instead of stopping after 5 failures in a row',
+        rich_help_panel=HelpPanels.actions,
+    ),
+]

--- a/boosty_downloader/src/cli/commands/download.py
+++ b/boosty_downloader/src/cli/commands/download.py
@@ -25,6 +25,7 @@ from boosty_downloader.src.cli.cli_options import (
     PostUrlOption,  # noqa: TC001
     PreferredVideoQualityOption,  # noqa: TC001
     RequestDelaySecondsOption,  # noqa: TC001
+    SkipAllFailuresOption,  # noqa: TC001
     UsernameOption,  # noqa: TC001
 )
 from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
@@ -79,6 +80,7 @@ async def _download_handler(  # noqa: PLR0913
     request_delay_seconds: float,
     destination_directory: Path | None,
     cache_directory: Path | None,
+    skip_all_failures: bool,
 ) -> None:
     async with initialized_app(
         username=username,
@@ -119,6 +121,7 @@ async def _download_handler(  # noqa: PLR0913
             boosty_api=app_env.boosty_api_client,
             destination=app_env.destination_directory,
             download_context=downloading_context,
+            skip_all_failures=skip_all_failures,
         ).execute()
 
 
@@ -138,6 +141,7 @@ def register(app: typer.Typer) -> None:
         preferred_video_quality: PreferredVideoQualityOption = VideoQualityOption.medium,
         destination_directory: DestinationDirectoryOption = None,
         cache_directory: CacheDirectoryOption = None,
+        skip_all_failures: SkipAllFailuresOption = False,
     ) -> None:
         """
         Download posts from a Boosty creator.
@@ -185,5 +189,6 @@ def register(app: typer.Typer) -> None:
                 request_delay_seconds=request_delay_seconds,
                 destination_directory=destination_directory,
                 cache_directory=cache_directory,
+                skip_all_failures=skip_all_failures,
             ),
         )

--- a/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
@@ -34,16 +34,27 @@ def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
 def format_run_summary(
     skipped_posts: Sequence[SkippedPost],
     unknown_content: AbstractSet[UnknownContent],
+    failed_posts: Sequence[str] = (),
 ) -> str | None:
     """
-    Build the final block about everything this run didn't understand.
+    Build the final block about everything this run skipped or didn't understand.
 
     Returns None when there is nothing to report, so clean runs stay silent.
     """
-    if not skipped_posts and not unknown_content:
+    if not skipped_posts and not unknown_content and not failed_posts:
         return None
 
-    lines = ['Some content was not understood by this version of the downloader:']
+    lines: list[str] = []
+    if failed_posts:
+        lines.append(
+            f'Posts that failed to download ({len(failed_posts)}), '
+            'details in failed_downloads.log:'
+        )
+        lines.extend(f'  - {item}' for item in failed_posts)
+    if not skipped_posts and not unknown_content:
+        return '\n'.join(lines)
+
+    lines.append('Some content was not understood by this version of the downloader:')
     if skipped_posts:
         lines.append(f' Skipped posts ({len(skipped_posts)}):')
         for skipped in skipped_posts:

--- a/test/unit/use_cases/download_all_posts_test.py
+++ b/test/unit/use_cases/download_all_posts_test.py
@@ -1,0 +1,248 @@
+"""Containment tests: one broken post must never kill or hollow out the run."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.exceptions.application_errors import (
+    ApplicationCancelledError,
+    ApplicationTooManyFailuresError,
+)
+from boosty_downloader.src.application.filtering import BoostyOkVideoType
+from boosty_downloader.src.application.use_cases.download_all_posts import (
+    DownloadAllPostUseCase,
+)
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+    PostsResponse,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from aiohttp_retry import RetryClient
+
+    from boosty_downloader.src.cli.console_progress_reporter import ProgressReporter
+    from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+        BoostyAPIClient,
+    )
+    from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+        ExternalVideosDownloader,
+    )
+    from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import (
+        FailedDownloadsLogger,
+    )
+    from boosty_downloader.src.infrastructure.post_caching.post_cache import (
+        SQLitePostCache,
+    )
+
+
+class _FakeReporter:
+    """Collects messages instead of rendering rich output."""
+
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
+    def create_task(self, *args: object, **kwargs: object) -> uuid.UUID:
+        del args, kwargs
+        return uuid.uuid4()
+
+    def update_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def complete_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def success(self, message: str) -> None:
+        del message
+
+    def notice(self, message: str) -> None:
+        del message
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+class _FakeFailedLogger:
+    """Collects failed-post log entries instead of writing a file."""
+
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, str]] = []
+
+    async def add_error(self, error_id: str, message: str) -> None:
+        self.entries.append((error_id, message))
+
+
+class _FakeApi:
+    """One page of posts, then stop."""
+
+    def __init__(self, page: PostsResponse) -> None:
+        self._page = page
+
+    async def iterate_over_posts(
+        self, *args: object, **kwargs: object
+    ) -> AsyncGenerator[PostsResponse, None]:
+        del args, kwargs
+        yield self._page
+
+
+def _post(post_id: str) -> PostDTO:
+    return PostDTO(
+        id=post_id,
+        title=f'post {post_id}',
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        has_access=True,
+        signed_query='',
+        data=[],
+    )
+
+
+def _use_case(
+    post_ids: list[str],
+    reporter: _FakeReporter,
+    failed_logger: _FakeFailedLogger,
+    *,
+    skip_all_failures: bool = False,
+) -> DownloadAllPostUseCase:
+    page = PostsResponse(
+        posts=[_post(post_id) for post_id in post_ids],
+        extra=Extra(offset='', is_last=True),
+    )
+    context = DownloadContext(
+        author_name='author',
+        downloader_session=cast('RetryClient', None),
+        external_videos_downloader=cast('ExternalVideosDownloader', None),
+        post_cache=cast('SQLitePostCache', None),
+        filters=[],
+        preferred_video_quality=BoostyOkVideoType.medium,
+        progress_reporter=cast('ProgressReporter', reporter),
+        failed_logger=cast('FailedDownloadsLogger', failed_logger),
+    )
+    return DownloadAllPostUseCase(
+        author_name='author',
+        boosty_api=cast('BoostyAPIClient', _FakeApi(page)),
+        destination=Path('unused'),
+        download_context=context,
+        skip_all_failures=skip_all_failures,
+    )
+
+
+def _script_outcomes(
+    monkeypatch: pytest.MonkeyPatch, outcomes: dict[str, Exception]
+) -> list[str]:
+    """Replace the single-post download with a script: raise by post id or succeed."""
+    calls: list[str] = []
+
+    async def scripted_execute(self: DownloadSinglePostUseCase) -> None:
+        calls.append(self.post_dto.id)
+        error = outcomes.get(self.post_dto.id)
+        if error is not None:
+            raise error
+
+    monkeypatch.setattr(DownloadSinglePostUseCase, 'execute', scripted_execute)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_skips_the_post_and_the_run_continues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for #88: an uncaught OSError used to kill the whole run."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    calls = _script_outcomes(monkeypatch, {'p1': OSError('File name too long')})
+
+    await _use_case(['p1', 'p2'], reporter, failed_logger).execute()
+
+    assert calls == ['p1', 'p2'], 'the run must reach the post after the broken one'
+    assert failed_logger.entries, 'the skip must land in failed_downloads.log'
+    assert failed_logger.entries[0][0] == 'p1'
+    summary = reporter.warnings[-1]
+    assert 'failed to download' in summary
+    assert 'post p1' in summary
+
+
+@pytest.mark.asyncio
+async def test_cancellation_reraises_and_stops_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl+C guard: the containment branch must never swallow cancellation."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    calls = _script_outcomes(
+        monkeypatch, {'p1': ApplicationCancelledError(post_uuid='p1')}
+    )
+
+    with pytest.raises(ApplicationCancelledError):
+        await _use_case(['p1', 'p2'], reporter, failed_logger).execute()
+
+    assert calls == ['p1'], 'nothing after the cancelled post may be downloaded'
+
+
+@pytest.mark.asyncio
+async def test_failure_streak_stops_the_run_with_a_systemic_diagnosis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A systemic cause must stop the run early, not grind through every post."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    post_ids = [f'p{n}' for n in range(1, 7)]
+    calls = _script_outcomes(
+        monkeypatch, {post_id: OSError('disk full') for post_id in post_ids}
+    )
+
+    with pytest.raises(ApplicationTooManyFailuresError):
+        await _use_case(post_ids, reporter, failed_logger).execute()
+
+    assert len(calls) == 5, 'the run must stop right at the threshold'
+    diagnosis = reporter.errors[-1]
+    assert 'systemic' in diagnosis
+    assert 'cached' in diagnosis, 'the stop message must explain how to resume'
+
+
+@pytest.mark.asyncio
+async def test_success_resets_the_streak(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Scattered failures are per-post problems - the run must reach the end."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    post_ids = [f'p{n}' for n in range(1, 10)]
+    failing = {post_id: OSError('flaky') for post_id in post_ids if post_id != 'p5'}
+    calls = _script_outcomes(monkeypatch, cast('dict[str, Exception]', failing))
+
+    await _use_case(post_ids, reporter, failed_logger).execute()
+
+    assert len(calls) == 9, 'four failures, a success, four more - never a stop'
+
+
+@pytest.mark.asyncio
+async def test_skip_all_failures_never_stops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The --skip-all-failures escape hatch: the run always reaches the end."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    post_ids = [f'p{n}' for n in range(1, 8)]
+    calls = _script_outcomes(
+        monkeypatch, {post_id: OSError('disk full') for post_id in post_ids}
+    )
+
+    await _use_case(post_ids, reporter, failed_logger, skip_all_failures=True).execute()
+
+    assert len(calls) == 7, 'every post must be attempted despite the streak'
+    summary = reporter.warnings[-1]
+    assert 'failed to download (7)' in summary


### PR DESCRIPTION
## Summary

One post with an unexpected error used to kill the whole download run (#88). Now the run skips it, remembers it, and only stops early when failures come in a row - a sign the problem is the environment, not the posts.

Fixes #88

## Problem

- The per-post loop caught only two known error types; anything else flew up and killed the run
- Real case from #88: a very long post title -> `OSError: File name too long` on folder creation -> the run is dead, everything after that post is not downloaded
- The user got a raw traceback, no summary, no idea what happened

## Fix

- An unexpected per-post error skips the post: it lands in `failed_downloads.log` and in the run summary, the run continues
- `FailureStreakBreaker`: 5 failed posts in a row stop the run - scattered failures are post problems, a streak means disk, permissions or network
- The stop message shows how many posts are done and that a re-run resumes from cache in seconds
- `--skip-all-failures` turns the streak stop off for a full pass no matter what
- Cancellation re-raises before the containment branch, so Ctrl+C keeps working

## Before / After

**Before:** one broken post killed the run with a raw traceback; a dead disk meant hours of retries over every remaining post.
**After:** broken posts are skipped and listed in the summary; a systemic cause stops the run within 5 posts with a diagnosis and a resume hint.

## Tests

- `test_unexpected_error_skips_the_post_and_the_run_continues` - the #88 regression: the next post still downloads
- `test_cancellation_reraises_and_stops_immediately` - Ctrl+C cannot be swallowed by the containment branch
- `test_failure_streak_stops_the_run_with_a_systemic_diagnosis` - stops exactly at the 5th failure, names the cause and the resume path
- `test_success_resets_the_streak` - scattered failures never stop the run
- `test_skip_all_failures_never_stops` - the escape hatch attempts every post
- Live: full `task ci` green, including 6 integration tests against the real Boosty API

## Notes

- The long-title post itself still fails and lands in `failed_downloads.log`: title length trimming is a separate fix on the roadmap
- README got a "When downloads fail" section, so users learn this behavior before they hit it
