### PR TITLE
[downloader] Keep every video when a post has several of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Multiple videos in one post no longer overwrite each other: filenames carry the video id, like `My stream (a2dd6942)` (#104)
 - One broken post no longer kills the whole download: it is skipped into failed_downloads.log and the run summary, and 5 failures in a row stop the run early with a resume hint (#88)
 
 ## 3.1.0

--- a/boosty_downloader/src/application/mappers/ok_boosty_video.py
+++ b/boosty_downloader/src/application/mappers/ok_boosty_video.py
@@ -32,6 +32,7 @@ def to_ok_boosty_video_content(
     best_video, choosed_quality = best_video_info
 
     return PostDataChunkBoostyVideo(
+        id=api_video_dto.id,
         url=best_video.url,
         title=api_video_dto.title,
         quality=choosed_quality.name,

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -71,6 +71,12 @@ def _form_post_url(username: str, post_id: str) -> str:
     return f'https://boosty.to/{username}/posts/{post_id}'
 
 
+def _boosty_video_filename(video: PostDataChunkBoostyVideo) -> str:
+    """Filename unique per video: titles repeat inside a post, ids never do."""
+    title = video.title.strip() or 'video'
+    return f'{title} ({video.id[:8]})'
+
+
 class DownloadSinglePostUseCase:
     """
     Use case for downloading all user's posts.
@@ -368,7 +374,7 @@ class DownloadSinglePostUseCase:
         """Download a Boosty video and return the path to the saved file."""
         return await self._download_with_progress(
             url=video.url,
-            filename=video.title,
+            filename=_boosty_video_filename(video),
             destination=self.boosty_videos_destination,
             task_label=f'[bold orange]Boosty Video[/bold orange]: {video.title}',
         )

--- a/boosty_downloader/src/domain/post_data_chunks.py
+++ b/boosty_downloader/src/domain/post_data_chunks.py
@@ -68,6 +68,9 @@ class PostDataChunkText:
 class PostDataChunkBoostyVideo:
     """Represent a Boosty video data chunk within a post."""
 
+    # Unique video id from the API: several videos in one post often share
+    # a title, the id keeps their filenames apart.
+    id: str
     title: str
     url: str
     quality: str

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
@@ -59,6 +59,7 @@ class BoostyPostDataOkVideoDTO(BoostyBaseDTO):
 
     type: Literal['ok_video']
 
+    id: str
     title: str
     failover_host: str
     duration: timedelta

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -56,6 +56,7 @@ def _make_ok_video(
 ) -> BoostyPostDataOkVideoDTO:
     return BoostyPostDataOkVideoDTO(
         type='ok_video',
+        id='vid-1',
         title='test video',
         failover_host='https://example.com',
         duration=timedelta(seconds=120),
@@ -177,6 +178,7 @@ def test_unknown_chunk_is_skipped_and_counted():
 def test_unknown_video_url_type_is_reported_not_fatal():
     video = BoostyPostDataOkVideoDTO(
         type='ok_video',
+        id='vid-1',
         title='test video',
         failover_host='https://example.com',
         duration=timedelta(seconds=120),

--- a/test/unit/use_cases/video_filename_test.py
+++ b/test/unit/use_cases/video_filename_test.py
@@ -1,0 +1,31 @@
+"""Regression tests for #104: several videos in one post must never share a filename."""
+
+from __future__ import annotations
+
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    _boosty_video_filename,
+)
+from boosty_downloader.src.domain.post import PostDataChunkBoostyVideo
+
+
+def _video(video_id: str, title: str) -> PostDataChunkBoostyVideo:
+    return PostDataChunkBoostyVideo(
+        id=video_id,
+        title=title,
+        url='https://example.com/video',
+        quality='medium',
+    )
+
+
+def test_videos_with_the_same_title_get_different_filenames() -> None:
+    """The #104 collision: same title used to mean same file, last one wins."""
+    first = _boosty_video_filename(_video('a2dd6942-7297-4340', 'My stream'))
+    second = _boosty_video_filename(_video('b3ee7053-8308-5451', 'My stream'))
+
+    assert first != second
+    assert first == 'My stream (a2dd6942)'
+
+
+def test_empty_title_falls_back_to_video_with_id() -> None:
+    """A nameless video must still get a readable, unique filename."""
+    assert _boosty_video_filename(_video('a2dd6942-7297', '  ')) == 'video (a2dd6942)'


### PR DESCRIPTION
## Summary

A post with two or more videos used to end up with a single file: all of them were written under the same name, and the last one won. Now every video filename carries the video id, so names cannot collide.

Fixes #104

## Problem

- A Boosty video file was named by its title alone
- Videos in one post often share a title (or have none), so they all pointed at the same path
- The file writer opens with `'wb'` and overwrites without a warning - earlier videos were lost silently

## Fix

- The API sends a unique `id` for every video - the client now parses it and hands it down to the domain
- Filenames become `My stream (a2dd6942)`: the id suffix is always there, so a name never depends on the neighbouring videos
- An empty title falls back to `video (a2dd6942)` instead of a bare bracket
- The HTML page still shows the human title - the suffix lives only in the filename

## Before / After

**Before:** a post with 3 videos leaves 1 file on disk, the other 2 are lost without a trace.
**After:** 3 videos - 3 files, each with a stable unique name.

## Tests

- `test_videos_with_the_same_title_get_different_filenames` - the #104 collision itself
- `test_empty_title_falls_back_to_video_with_id` - nameless videos stay readable and unique
- Live integration suite (6 passed) confirms the real API sends the `id` field on every post

## Notes

- Already-downloaded videos keep their old names: the cache works by post id, nothing gets re-downloaded
- New downloads use the new naming - mentioned in the changelog entry
