### PR TITLE
[downloader] Make network waits finite so a silent server cannot hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- The app can no longer hang forever: a silent server connection now times out and goes through the usual retries, and an unreachable PyPI delays startup by 5 seconds at most
 - A broken config.yaml is reported with exact fields and line numbers instead of being silently replaced - the saved token survives
 - Multiple videos in one post no longer overwrite each other: filenames carry the video id, like `My stream (a2dd6942)` (#104)
 - One broken post no longer kills the whole download: it is skipped into failed_downloads.log and the run summary, and 5 failures in a row stop the run early with a resume hint (#88)

--- a/boosty_downloader/src/application/di/app_environment.py
+++ b/boosty_downloader/src/application/di/app_environment.py
@@ -68,7 +68,12 @@ class AppEnvironment:
             aiohttp.ClientSession(
                 headers=self.boosty_headers,
                 cookie_jar=self.boosty_cookies_jar,
-                timeout=aiohttp.ClientTimeout(total=None),
+                # No limit on the whole download: big videos legally take
+                # hours. Limits are on silence only - a dead connection must
+                # surface as an error, not as an eternal hang:
+                # - connect: a healthy server answers in under a second
+                # - sock_read: max quiet time between received chunks
+                timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=90),
                 trust_env=True,
             )
         )

--- a/boosty_downloader/src/application/di/initialized_app.py
+++ b/boosty_downloader/src/application/di/initialized_app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib.metadata
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
@@ -81,7 +82,8 @@ async def initialized_app(
         },
     )
 
-    _check_and_log_updates()
+    # to_thread: the PyPI request is blocking; the event loop stays free.
+    await asyncio.to_thread(_check_and_log_updates)
 
     async with AppEnvironment(
         config=AppEnvironment.AppConfig(

--- a/boosty_downloader/src/infrastructure/update_checker/pypi_checker.py
+++ b/boosty_downloader/src/infrastructure/update_checker/pypi_checker.py
@@ -11,6 +11,10 @@ from urllib.request import urlopen
 
 from packaging import version
 
+# The update notice is a courtesy, not a feature worth waiting for:
+# an unreachable PyPI must not delay the start of the actual work.
+PYPI_TIMEOUT_SECONDS = 5
+
 
 class UpdateCheckStatus(Enum):
     """Represents the status of an update check."""
@@ -44,7 +48,10 @@ UpdateResult = UpdateAvailable | NoUpdate | CheckFailed
 def get_pypi_latest_version(package_name: str) -> str | None:
     """Fetch the latest version string of a package from PyPI."""
     try:
-        with urlopen(f'https://pypi.org/pypi/{package_name}/json') as resp:
+        with urlopen(
+            f'https://pypi.org/pypi/{package_name}/json',
+            timeout=PYPI_TIMEOUT_SECONDS,
+        ) as resp:
             data = json.load(resp)
             return data['info']['version']
     except Exception:  # noqa: BLE001 It doesn't matter what exception is raised, we just need to 100% catch it


### PR DESCRIPTION
## Summary

Two network calls had no time limit. A server that goes quiet without closing the connection froze the app forever - no error, no retry, just a progress bar stuck at 43% until the user notices in the morning.

## Problem

- The download session was built with `ClientTimeout(total=None)` and nothing else: a connection that stops sending data is waited on forever
- The PyPI update check at startup used `urlopen` with no timeout: with PyPI unreachable (firewall, broken DNS) every command froze before doing any work
- A hang is worse than an error: errors go through retries and the failure-streak stop, a hang is invisible

## Fix

- The session limits silence, not duration: 30s to connect, 90s max between received chunks, no limit on the whole download - big videos still take as long as they need
- A timed-out connection raises a normal client error and joins the existing chain: retries, then skip into `failed_downloads.log`, then the failure-streak stop if everything is down
- The update check waits 5 seconds at most and runs off the event loop (`asyncio.to_thread`)

## Before / After

**Before:** wifi dies at 2am without closing the connection - the run is frozen until morning, nothing in the logs.
**After:** 90 seconds of silence turn into a retryable error; the night run either recovers by itself or stops with a diagnosis and resumes from cache.

## Verification

- Live mechanics test: a local server that accepts a connection and sends nothing - the request dies exactly at the `sock_read` limit (`SocketTimeoutError`), same for an unroutable address; no hang
- The timeout error type is already in the transport client's retry list - no new handling branches were needed
- Full `task ci` green: checks, 64 unit tests, 6 live integration tests, build

## Notes

- No unit tests for the constant values on purpose: asserting `30 == 30` has no failure story
- Moving the update check out of the DI layer entirely is a separate roadmap step; this change only bounds and unblocks it
