### PR TITLE
[downloader] Keep file extensions and stop producing .bin files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Files keep their real extensions: a server answering "type unknown" no longer renames archive.zip into archive.bin, and dots inside titles no longer truncate filenames (#75)
+- Files and audio keep exactly the name the author uploaded - no more archive.zip turning into archive.bin (#75); images finally get an extension (.png/.jpg) instead of a bare uuid
 - The app can no longer hang forever: a silent server connection now times out and goes through the usual retries, and an unreachable PyPI delays startup by 5 seconds at most
 - A broken config.yaml is reported with exact fields and line numbers instead of being silently replaced - the saved token survives
 - Multiple videos in one post no longer overwrite each other: filenames carry the video id, like `My stream (a2dd6942)` (#104)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Files keep their real extensions: a server answering "type unknown" no longer renames archive.zip into archive.bin, and dots inside titles no longer truncate filenames (#75)
 - The app can no longer hang forever: a silent server connection now times out and goes through the usual retries, and an unreachable PyPI delays startup by 5 seconds at most
 - A broken config.yaml is reported with exact fields and line numbers instead of being silently replaced - the saved token survives
 - Multiple videos in one post no longer overwrite each other: filenames carry the video id, like `My stream (a2dd6942)` (#104)

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -416,6 +416,8 @@ class DownloadSinglePostUseCase:
             filename=file.filename,
             destination=self.files_destination,
             task_label=f'File: {file.filename}',
+            # The author's original filename already carries its extension.
+            guess_extension=False,
         )
 
     async def download_image(self, image: PostDataChunkImage) -> Path:
@@ -425,7 +427,9 @@ class DownloadSinglePostUseCase:
             filename=URL(image.url).name,
             destination=self.images_destination,
             task_label=f'Image: {URL(image.url).name}',
-            guess_extension=False,
+            # The name is a bare uuid - Content-Type is the only source
+            # of an extension in existence.
+            guess_extension=True,
         )
 
     async def download_audio(self, audio: PostDataChunkAudio) -> Path:

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import http
 import mimetypes
-import re
 from asyncio import CancelledError
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -48,6 +47,9 @@ class DownloadFileConfig:
     destination: Path
     on_status_update: Callable[[DownloadingStatus], None] = lambda _: None
 
+    # True only when the caller builds the filename without an extension
+    # (videos, images). Names that come from the author (files, audio)
+    # already carry their extension and must never be touched.
     guess_extension: bool = True
     chunk_size_bytes: int = 524288  # 512 KiB
 
@@ -114,21 +116,14 @@ class DownloadUnexpectedStatusError(DownloadError):
         self.response_message = response_message
 
 
-# A trailing dot plus 1-5 letters/digits, like ".zip" or ".mp4".
-# A dot inside a title ("Ep. 5 (a2dd6942)") does not count.
-_REAL_EXTENSION = re.compile(r'\.[A-Za-z0-9]{1,5}$')
-
-
-def _extension_to_append(filename: str, content_type: str | None) -> str | None:
+def _extension_to_append(content_type: str | None) -> str | None:
     """
-    Pick an extension to add to a name that has none.
+    Pick an extension for a name that has none by construction.
 
-    An existing extension always wins over the server's opinion, and
-    'application/octet-stream' ("bytes, type unknown") teaches us nothing -
-    no more ".bin" files born out of that.
+    Only callers whose filenames are built without an extension (videos,
+    images) ask for this. 'application/octet-stream' ("bytes, type
+    unknown") teaches nothing - no ".bin" is ever born out of it.
     """
-    if _REAL_EXTENSION.search(filename):
-        return None
     if not content_type or content_type == 'application/octet-stream':
         return None
     return mimetypes.guess_extension(content_type)
@@ -150,7 +145,7 @@ async def download_file(
         file_path = dl_config.destination / filename
 
         if dl_config.guess_extension:
-            ext = _extension_to_append(filename, response.content_type)
+            ext = _extension_to_append(response.content_type)
             if ext is not None:
                 file_path = file_path.with_name(file_path.name + ext)
 

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import http
 import mimetypes
+import re
 from asyncio import CancelledError
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -113,6 +114,26 @@ class DownloadUnexpectedStatusError(DownloadError):
         self.response_message = response_message
 
 
+# A trailing dot plus 1-5 letters/digits, like ".zip" or ".mp4".
+# A dot inside a title ("Ep. 5 (a2dd6942)") does not count.
+_REAL_EXTENSION = re.compile(r'\.[A-Za-z0-9]{1,5}$')
+
+
+def _extension_to_append(filename: str, content_type: str | None) -> str | None:
+    """
+    Pick an extension to add to a name that has none.
+
+    An existing extension always wins over the server's opinion, and
+    'application/octet-stream' ("bytes, type unknown") teaches us nothing -
+    no more ".bin" files born out of that.
+    """
+    if _REAL_EXTENSION.search(filename):
+        return None
+    if not content_type or content_type == 'application/octet-stream':
+        return None
+    return mimetypes.guess_extension(content_type)
+
+
 async def download_file(
     dl_config: DownloadFileConfig,
 ) -> Path:
@@ -128,11 +149,10 @@ async def download_file(
         filename = sanitize_string(dl_config.filename)
         file_path = dl_config.destination / filename
 
-        content_type = response.content_type
-        if content_type and dl_config.guess_extension:
-            ext = mimetypes.guess_extension(content_type)
+        if dl_config.guess_extension:
+            ext = _extension_to_append(filename, response.content_type)
             if ext is not None:
-                file_path = file_path.with_suffix(ext)
+                file_path = file_path.with_name(file_path.name + ext)
 
         total_downloaded = 0
 

--- a/test/unit/file_downloader/extension_guessing_test.py
+++ b/test/unit/file_downloader/extension_guessing_test.py
@@ -1,32 +1,95 @@
-"""Regression tests for #75: downloads keep their extensions and never get .bin."""
+"""Regression tests for #75: the extension policy follows the name's origin.
+
+Names from the author (files, audio) already carry their extension and are
+never touched. Names built by the app (videos, images) have no extension by
+construction - the content type appends one, and "type unknown" appends
+nothing, so ".bin" files are never born.
+"""
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+)
+from boosty_downloader.src.domain.post import (
+    PostDataChunkAudio,
+    PostDataChunkBoostyVideo,
+    PostDataChunkFile,
+    PostDataChunkImage,
+)
 from boosty_downloader.src.infrastructure.file_downloader import _extension_to_append
 
+if TYPE_CHECKING:
+    from boosty_downloader.src.application.di.download_context import DownloadContext
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 
-def test_octet_stream_never_replaces_a_real_extension() -> None:
-    """The live #75 case: the server serves an .m4a file as 'unknown bytes'."""
-    assert (
-        _extension_to_append('Песня-присциллы.m4a', 'application/octet-stream') is None
+
+def test_type_unknown_never_produces_an_extension() -> None:
+    """'application/octet-stream' means "bytes" - .bin must not be born from it."""
+    assert _extension_to_append('application/octet-stream') is None
+    assert _extension_to_append(None) is None
+
+
+def test_informative_content_type_gives_the_extension() -> None:
+    assert _extension_to_append('video/mp4') == '.mp4'
+    assert _extension_to_append('image/png') == '.png'
+
+
+def _use_case_with_captured_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[DownloadSinglePostUseCase, dict[str, bool]]:
+    captured: dict[str, bool] = {}
+
+    async def fake_download(
+        self: DownloadSinglePostUseCase,
+        **kwargs: object,
+    ) -> Path:
+        del self
+        captured[str(kwargs['filename'])] = bool(kwargs.get('guess_extension', True))
+        return Path(str(kwargs['filename']))
+
+    monkeypatch.setattr(
+        DownloadSinglePostUseCase, '_download_with_progress', fake_download
     )
+    use_case = DownloadSinglePostUseCase(
+        destination=Path('unused'),
+        post_dto=cast('PostDTO', None),
+        download_context=cast('DownloadContext', None),
+    )
+    return use_case, captured
 
 
-def test_octet_stream_never_invents_bin() -> None:
-    """'Type unknown' teaches nothing - an extensionless name stays as is."""
-    assert _extension_to_append('noname', 'application/octet-stream') is None
+@pytest.mark.asyncio
+async def test_author_names_are_never_touched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The #75 regression: flipping files back to guessing revives .bin."""
+    use_case, captured = _use_case_with_captured_flags(monkeypatch)
+
+    await use_case.download_files(PostDataChunkFile(url='u', filename='any.appimage'))
+    await use_case.download_audio(PostDataChunkAudio(url='u', title='song.mp3'))
+
+    assert captured == {'any.appimage': False, 'song.mp3': False}
 
 
-def test_a_lying_server_cannot_replace_an_extension() -> None:
-    """A misconfigured server saying text/html must not turn report.pdf into .html."""
-    assert _extension_to_append('report.pdf', 'text/html') is None
+@pytest.mark.asyncio
+async def test_app_built_names_ask_for_an_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Videos and images have no extension by construction - the content type adds one."""
+    use_case, captured = _use_case_with_captured_flags(monkeypatch)
 
+    await use_case.download_boosty_video(
+        PostDataChunkBoostyVideo(
+            id='a2dd6942', title='Update v1.2', url='u', quality='medium'
+        )
+    )
+    await use_case.download_image(PostDataChunkImage(url='https://cdn/image/40f9e868'))
 
-def test_extensionless_video_gets_an_extension_from_content_type() -> None:
-    """Video filenames carry no extension - the informative content type adds one."""
-    assert _extension_to_append('My stream (a2dd6942)', 'video/mp4') == '.mp4'
-
-
-def test_a_dot_inside_a_title_is_not_an_extension() -> None:
-    """with_suffix used to truncate 'Ep. 5 (id)' to 'Ep.mp4' - append keeps the name."""
-    assert _extension_to_append('Ep. 5 (b3ee7053)', 'video/mp4') == '.mp4'
+    assert len(captured) == 2
+    assert all(captured.values()), f'both must ask for an extension: {captured}'

--- a/test/unit/file_downloader/extension_guessing_test.py
+++ b/test/unit/file_downloader/extension_guessing_test.py
@@ -1,0 +1,32 @@
+"""Regression tests for #75: downloads keep their extensions and never get .bin."""
+
+from __future__ import annotations
+
+from boosty_downloader.src.infrastructure.file_downloader import _extension_to_append
+
+
+def test_octet_stream_never_replaces_a_real_extension() -> None:
+    """The live #75 case: the server serves an .m4a file as 'unknown bytes'."""
+    assert (
+        _extension_to_append('Песня-присциллы.m4a', 'application/octet-stream') is None
+    )
+
+
+def test_octet_stream_never_invents_bin() -> None:
+    """'Type unknown' teaches nothing - an extensionless name stays as is."""
+    assert _extension_to_append('noname', 'application/octet-stream') is None
+
+
+def test_a_lying_server_cannot_replace_an_extension() -> None:
+    """A misconfigured server saying text/html must not turn report.pdf into .html."""
+    assert _extension_to_append('report.pdf', 'text/html') is None
+
+
+def test_extensionless_video_gets_an_extension_from_content_type() -> None:
+    """Video filenames carry no extension - the informative content type adds one."""
+    assert _extension_to_append('My stream (a2dd6942)', 'video/mp4') == '.mp4'
+
+
+def test_a_dot_inside_a_title_is_not_an_extension() -> None:
+    """with_suffix used to truncate 'Ep. 5 (id)' to 'Ep.mp4' - append keeps the name."""
+    assert _extension_to_append('Ep. 5 (b3ee7053)', 'video/mp4') == '.mp4'


### PR DESCRIPTION
## Summary

The downloader used to trust the server's content type over the filename and renamed `archive.zip` into `archive.bin`. Research showed there is no universal way to tell whether a name "has an extension" - so the code stops asking. Every download site declares where its name came from, and that origin decides everything.

Fixes #75

## Problem

- The CDN serves file attachments as `application/octet-stream` ("bytes, type unknown"); `mimetypes` turns that into `.bin` and the old code replaced the author's real extension with it
- Any letter-counting heuristic breaks both ways: `.appimage` is a real extension longer than the window, and a video titled `Update v1.2` looks like it ends with one
- Live probes of the raw API and all CDN response headers proved the split: files and audio come with the author's original filename, videos and images have no name anywhere - `Content-Type` is the only source in existence

## Fix

The extension policy follows the name's origin, with zero name heuristics:

- Names from the author (files, audio): never touched, whatever the server says - `.doc`, `.appimage`, anything works
- Names built by the app (videos, images): an informative content type always appends an extension; `octet-stream` appends nothing, so `.bin` is never born
- Extensions are appended to the whole name, not swapped in - dots inside titles cannot truncate it
- Images finally get `.png`/`.jpg` instead of a bare uuid

## Before / After

**Before:** `file-sample_1MB.doc` lands as `file-sample_1MB.bin`; images land as extensionless uuids.
**After:** the file keeps its name; the image becomes `40f9e868-….png`; the video becomes `Some title (a2dd6942).mp4`.

## Tests

- Unit: the octet-stream guard, the content-type source, and two policy guards - flipping `download_files` back to guessing revives `.bin` and fails the suite
- Live, all four chunk kinds through the real app: file (`.doc` intact, content verified), audio (`.mp3` intact), video (`.mp4` appended), image (`.png` appended)
- Idempotency: a re-run hits the cache, names stay stable; the generated `post.html` references the new names correctly
- A full channel download passes end to end; full `task ci` green

## Notes

- The magic-bytes utility proposed in #75 stays on the roadmap for historic downloads; the probes also mapped richer sources for it (`Content-Disposition` on files, the `fileType` field on audio)
