### PR TITLE
[docs] Explain why the download walk uses small listing pages

### DIFF
--- a/boosty_downloader/src/infrastructure/boosty_api/core/client.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/core/client.py
@@ -220,6 +220,10 @@ class BoostyAPIClient:
     async def iterate_over_posts(
         self,
         author_name: str,
+        # Small default on purpose: signed media links live 24 hours from
+        # the listing fetch, and the download walk is sequential - a small
+        # page keeps links fresh by the time their post's turn comes.
+        # Metadata-only walks (check, post search) pass MAX_POSTS_PER_PAGE.
         posts_per_page: int = 5,
     ) -> AsyncGenerator[PostsResponse, None]:
         """

--- a/docs/concepts/boosty/download-flow.md
+++ b/docs/concepts/boosty/download-flow.md
@@ -22,6 +22,14 @@ CLI (typer)
 5. **Render.** Chunks processed in this run become `post.html` via Jinja templates.
 6. **Remember.** The cache records which content types finished, so the next run downloads only what is missing.
 
+## Page size and the 24-hour links
+
+Media links in a listing answer are signed and live 24 hours from the fetch.
+
+- The download walk uses small pages (5 posts) on purpose. Posts download one by one, and a small page means every link is still fresh when its post's turn comes.
+- Metadata-only walks use pages of 100: counting posts in `check` and finding a post by url download nothing between pages, so nothing can get old - and the walk makes 20x fewer requests.
+- If a page still outlives its links (a huge video queue on a slow connection), those downloads fail, the failure-streak stop fires, and a re-run continues from the cache with fresh links.
+
 ## Layers
 
 - `cli/` - typer commands and console output


### PR DESCRIPTION
## Summary

Signed media links live 24 hours from the listing fetch (measured live), so the sequential download walks in small pages of 5 to keep links fresh, while metadata-only walks (`check`, post search) use pages of 100. This was undocumented and one comment away from a well-meaning "optimization" that would multiply link expiry failures on big video channels. A new section in `docs/concepts/boosty/download-flow.md` and a comment on the client default capture the reasoning.
