### PR TITLE
[cli] Add a --version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+- `--version` / `-V` flag shows the installed version
 - `--skip-all-failures` flag: skip failed posts without limit instead of stopping after 5 failures in a row
 
 ### Fixed

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.metadata
+from typing import Annotated
+
 import typer
 from aiohttp.client_exceptions import ClientConnectorDNSError
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
@@ -36,8 +39,26 @@ typer_app = typer.Typer(
 )
 
 
+def _print_version(value: bool) -> None:  # noqa: FBT001 - typer callback contract
+    if value:
+        typer.echo(importlib.metadata.version('boosty-downloader'))
+        raise typer.Exit
+
+
 @typer_app.callback()
-def _app_callback(ctx: typer.Context) -> None:  # pyright: ignore[reportUnusedFunction]
+def _app_callback(  # pyright: ignore[reportUnusedFunction]
+    ctx: typer.Context,
+    _version: Annotated[  # noqa: FBT002 - typer flag contract
+        bool,
+        typer.Option(
+            '--version',
+            '-V',
+            help='Show the version and exit',
+            callback=_print_version,
+            is_eager=True,
+        ),
+    ] = False,
+) -> None:
     """
     CLI tool to download Boosty posts by author username.
 


### PR DESCRIPTION
## Summary

`boosty-downloader --version` used to answer "No such option" - the app knew its version (the update checker uses it) but never showed it to the user. Now `--version` / `-V` prints the installed version and exits before any other work: no config read, no network.

## How it works

- An eager typer option on the root callback - the canonical pattern from the typer docs
- The version comes from the installed package metadata, the same source the update checker reads
- Works even with garbage in the other arguments: the flag is processed first

## Tests

- Verified live: `--version` and `-V` print the version instantly, with and without a config present
