### PR TITLE
chore: release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.2.0
+
 ### Added
 
 - `--version` / `-V` flag shows the installed version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boosty-downloader"
-version = "3.1.0"
+version = "3.2.0"
 description = "Download any type of content from boosty.to"
 authors = [{ name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" }]
 requires-python = ">=3.10,<4"


### PR DESCRIPTION
Promotes the Unreleased changelog into v3.2.0 and bumps the version.

## Release notes

### Added

- `--version` / `-V` flag shows the installed version
- `--skip-all-failures` flag: skip failed posts without limit instead of stopping after 5 failures in a row

### Fixed

- Files and audio keep exactly the name the author uploaded - no more archive.zip turning into archive.bin (#75); images finally get an extension (.png/.jpg) instead of a bare uuid
- The app can no longer hang forever: a silent server connection now times out and goes through the usual retries, and an unreachable PyPI delays startup by 5 seconds at most
- A broken config.yaml is reported with exact fields and line numbers instead of being silently replaced - the saved token survives
- Multiple videos in one post no longer overwrite each other: filenames carry the video id, like `My stream (a2dd6942)` (#104)
- One broken post no longer kills the whole download: it is skipped into failed_downloads.log and the run summary, and 5 failures in a row stop the run early with a resume hint (#88)

## After merge

Run `task release:tag` - it verifies fresh main and pushes the tag; the tag triggers the release workflow (build -> PyPI -> GitHub Release).
