### PR TITLE
chore: release v3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.3.0
+
 ### Added
 
 - `--debug` flag writes `boosty-downloader-debug.log`: app version, platform, every request and full error tracebacks - attach it to bug reports; download links are logged without their signed keys, so the file is safe for public issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boosty-downloader"
-version = "3.2.0"
+version = "3.3.0"
 description = "Download any type of content from boosty.to"
 authors = [{ name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "boosty-downloader"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Promotes the Unreleased changelog into v3.3.0 and bumps the version.

## Release notes

### Added

- `--debug` flag writes `boosty-downloader-debug.log`: app version, platform, every request and full error tracebacks - attach it to bug reports; download links are logged without their signed keys, so the file is safe for public issues

### Fixed

- Network errors now say what actually broke instead of a generic connection message: a DNS failure names the host and suggests trying another DNS or a VPN that covers all apps (#109)

## After merge

Run `task release:tag` - it verifies fresh main and pushes the tag; the tag triggers the release workflow (build -> PyPI -> GitHub Release).
