### PR TITLE
[debug-log] Keep query keys in logged URLs, mask only the values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Changed
+
+- Debug log now keeps query keys in logged URLs (`?sig=...&expire=...` instead of cutting the query off) - easier to match a failing request to an endpoint, values stay hidden
+
 ## 3.3.0
 
 ### Added

--- a/boosty_downloader/src/infrastructure/loggers/request_tracing.py
+++ b/boosty_downloader/src/infrastructure/loggers/request_tracing.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING
-from urllib.parse import urlsplit
+from urllib.parse import parse_qsl, urlsplit
 
 from aiohttp import TraceConfig
 
@@ -25,12 +25,17 @@ def redacted_url(url: str) -> str:
     """
     Make a URL safe for the log file.
 
-    The query string carries signed, expiring credentials - the log is
-    meant to be attached to public issues, so only scheme, host and path
-    survive.
+    Query values carry signed, expiring credentials - the log is meant
+    to be attached to public issues, so values are masked. Query keys
+    stay: they show the request shape without giving anything away.
     """
     parts = urlsplit(url)
-    return f'{parts.scheme}://{parts.netloc}{parts.path}'
+    base = f'{parts.scheme}://{parts.netloc}{parts.path}'
+    if not parts.query:
+        return base
+    keys = [key for key, _ in parse_qsl(parts.query, keep_blank_values=True)]
+    masked_query = '&'.join(f'{key}=...' for key in keys)
+    return f'{base}?{masked_query}'
 
 
 async def _log_request_start(

--- a/test/unit/loggers/request_tracing_test.py
+++ b/test/unit/loggers/request_tracing_test.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from boosty_downloader.src.infrastructure.loggers.request_tracing import redacted_url
 
 
-def test_redacted_url_drops_the_signed_query() -> None:
-    """A logged CDN link with its query would hand out working credentials."""
+def test_redacted_url_masks_query_values_but_keeps_keys() -> None:
+    """Values are working credentials; keys are needed to match the endpoint."""
     url = 'https://cdn.boosty.to/file/181ac169?sig=SECRET&expire=1770000000'
 
-    assert redacted_url(url) == 'https://cdn.boosty.to/file/181ac169'
+    assert redacted_url(url) == 'https://cdn.boosty.to/file/181ac169?sig=...&expire=...'
 
 
 def test_redacted_url_keeps_a_plain_url_intact() -> None:


### PR DESCRIPTION
## Summary

The debug log used to cut the whole query string off every logged URL. Now it keeps the keys and masks only the values: `?sig=...&expire=...` instead of nothing. The log stays safe to attach to public issues, but a failing request can finally be matched to a concrete endpoint call shape.

## Problem

- `redacted_url` dropped everything after the path, so two different requests to the same path looked identical in the log
- For paginated API calls (`?offset=...&limit=...`) the query keys are the only thing that tells one page request from another
- The keys themselves carry no secrets - only the values do (signatures, expiry timestamps)

## Fix

- `redacted_url` now parses the query and rewrites every pair as `key=...`, preserving key order and duplicates
- URLs without a query are returned unchanged, same as before

## Before / After

**Before:** `GET https://api.boosty.to/v1/blog/boosty/post/`
**After:** `GET https://api.boosty.to/v1/blog/boosty/post/?offset=...&limit=...`

## Verification

- Live run: `--debug check --username boosty` - the log shows `?limit=...` and `?offset=...&limit=...` lines, no values anywhere
- Updated unit test asserts a signed CDN link keeps `sig` and `expire` keys but not the `SECRET` value; the plain-URL test still passes
- `task check` green (ruff, format, pyright), all 73 unit tests pass