### PR TITLE
[downloader] Fit every generated name into the filesystem limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 ## Unreleased
 
+### Fixed
+
+- Long post titles no longer crash the download with "File name too long" (#93, #88): folder and file names are cut to fit the filesystem limit, and the post date, the dedup id and the file extension always survive the cut
+- If the full path is still too long for the OS (a deep destination folder on Windows), the error now says what to do: move the destination folder closer to the drive root
+- Titles with dots keep them: a post named "v2.0" no longer turns into "v20"
+
 ### Changed
 
+- Single-post downloads (`--post-url`) now name the folder the same way as the full run: `date - title (id)` - the id tail keeps same-titled posts apart
 - Debug log now keeps query keys in logged URLs (`?sig=...&expire=...` instead of cutting the query off) - easier to match a failing request to an endpoint, values stay hidden
+- Already downloaded posts are untouched: folders are never renamed, a new-style name appears only when an updated post is re-downloaded
 
 ## 3.3.0
 

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -14,6 +14,7 @@ from boosty_downloader.src.application.exceptions.application_errors import (
 from boosty_downloader.src.application.failure_streak import FailureStreakBreaker
 from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
+    compose_post_directory_name,
 )
 from boosty_downloader.src.infrastructure.boosty_api.core.client import BoostyAPIClient
 from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
@@ -23,9 +24,6 @@ from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content impo
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
     format_run_summary,
     format_skipped_post,
-)
-from boosty_downloader.src.infrastructure.path_sanitizer import (
-    sanitize_string,
 )
 
 # Failures of posts in a row, without a single success in between.
@@ -208,16 +206,9 @@ class DownloadAllPostUseCase:
                     )
                     continue
 
-                # For empty titles use post ID as a fallback (first 8 chars)
-                if len(post_dto.title) == 0:
-                    post_dto.title = f'No title (id_{post_dto.id[:8]})'
-
-                post_dto.title = (
-                    sanitize_string(post_dto.title).replace('.', '').strip()
+                full_post_title = compose_post_directory_name(
+                    post_dto.title, post_dto.created_at, post_dto.id
                 )
-
-                # date - TITLE (UUID_PART) for deduplication in case of same names with different posts
-                full_post_title = f'{post_dto.created_at.date()} - {post_dto.title} ({post_dto.id[:8]})'
 
                 single_post_use_case = DownloadSinglePostUseCase(
                     destination=self.destination / full_post_title,

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -25,6 +25,10 @@ from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors imp
     format_run_summary,
     format_skipped_post,
 )
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    PATH_TOO_LONG_HINT,
+    is_path_too_long_error,
+)
 
 # Failures of posts in a row, without a single success in between.
 # Scattered failures are per-post problems; a streak like this almost
@@ -129,9 +133,11 @@ class DownloadAllPostUseCase:
         attempts: int,
     ) -> _PostOutcome:
         """Give up on a post whose known failure survived all retries."""
-        failed_posts.append(f'{full_post_title} ({error.message})')
+        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
+        failed_posts.append(f'{full_post_title} ({error.message}){hint}')
         self.context.progress_reporter.error(
-            f'Skip post after {attempts} failed attempts: {full_post_title} ({error.message})'
+            f'Skip post after {attempts} failed attempts: '
+            f'{full_post_title} ({error.message}){hint}'
         )
         return _PostOutcome.failed
 
@@ -143,13 +149,14 @@ class DownloadAllPostUseCase:
         error: Exception,
     ) -> _PostOutcome:
         """Give up on a post immediately: unexpected errors do not heal by retrying."""
-        failed_posts.append(f'{full_post_title} ({error})')
+        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
+        failed_posts.append(f'{full_post_title} ({error}){hint}')
         self.context.progress_reporter.error(
-            f'Skip post after unexpected error: {full_post_title} ({error})'
+            f'Skip post after unexpected error: {full_post_title} ({error}){hint}'
         )
         await self.context.failed_logger.add_error(
             post_id,
-            f'Unexpected error: {error}',
+            f'Unexpected error: {error}{hint}',
         )
         return _PostOutcome.failed
 

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -6,6 +6,7 @@ It encapsulates the logic required to download a post from a specific author.
 
 import uuid
 from asyncio import CancelledError, to_thread
+from datetime import datetime
 from pathlib import Path
 
 from yarl import URL
@@ -65,6 +66,10 @@ from boosty_downloader.src.infrastructure.html_generator.renderer import (
 from boosty_downloader.src.infrastructure.human_readable_filesize import (
     human_readable_size,
 )
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    MAX_NAME_BYTES,
+    sanitize_filename,
+)
 
 
 def _form_post_url(username: str, post_id: str) -> str:
@@ -75,6 +80,20 @@ def _boosty_video_filename(video: PostDataChunkBoostyVideo) -> str:
     """Filename unique per video: titles repeat inside a post, ids never do."""
     title = video.title.strip() or 'video'
     return f'{title} ({video.id[:8]})'
+
+
+def compose_post_directory_name(title: str, created_at: datetime, post_id: str) -> str:
+    """
+    One folder per post: 'YYYY-MM-DD - Title (id8)'.
+
+    The id tail keeps two same-titled posts apart; the title is cut to
+    fit the filesystem name limit, the date and the id always survive.
+    """
+    clean_title = title.strip() or 'No title'
+    prefix = f'{created_at.date()} - '
+    suffix = f' ({post_id[:8]})'
+    budget = MAX_NAME_BYTES - len(prefix.encode('utf-8'))
+    return prefix + sanitize_filename(clean_title, suffix=suffix, max_bytes=budget)
 
 
 class DownloadSinglePostUseCase:

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -76,10 +76,19 @@ def _form_post_url(username: str, post_id: str) -> str:
     return f'https://boosty.to/{username}/posts/{post_id}'
 
 
+# download_file appends a guessed extension to video names later:
+# the byte budget here leaves room so that never re-truncates the name.
+_GUESSED_EXTENSION_RESERVE_BYTES = 8
+
+
 def _boosty_video_filename(video: PostDataChunkBoostyVideo) -> str:
     """Filename unique per video: titles repeat inside a post, ids never do."""
     title = video.title.strip() or 'video'
-    return f'{title} ({video.id[:8]})'
+    return sanitize_filename(
+        title,
+        suffix=f' ({video.id[:8]})',
+        max_bytes=MAX_NAME_BYTES - _GUESSED_EXTENSION_RESERVE_BYTES,
+    )
 
 
 def compose_post_directory_name(title: str, created_at: datetime, post_id: str) -> str:

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -24,6 +24,10 @@ from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors imp
     format_run_summary,
     format_skipped_post,
 )
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    PATH_TOO_LONG_HINT,
+    is_path_too_long_error,
+)
 
 if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.post import (
@@ -159,8 +163,9 @@ class DownloadPostByUrlUseCase:
             self.context.progress_reporter.warn('Download cancelled by user. Bye!')
             return _PostDownloadOutcome.cancelled
         except ApplicationFailedDownloadError as e:
+            hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(e) else ''
             self.context.progress_reporter.error(
-                f'Failed to download post: {e.message}, RESOURCE: ({e.resource})'
+                f'Failed to download post: {e.message}, RESOURCE: ({e.resource}){hint}'
             )
             return _PostDownloadOutcome.failed
         return _PostDownloadOutcome.downloaded

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -14,6 +14,7 @@ from boosty_downloader.src.application.use_cases.check_total_posts import (
 from boosty_downloader.src.application.use_cases.download_single_post import (
     ApplicationFailedDownloadError,
     DownloadSinglePostUseCase,
+    compose_post_directory_name,
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
     collect_unknown_content,
@@ -23,7 +24,6 @@ from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors imp
     format_run_summary,
     format_skipped_post,
 )
-from boosty_downloader.src.infrastructure.file_downloader import sanitize_string
 
 if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.post import (
@@ -147,12 +147,7 @@ class DownloadPostByUrlUseCase:
         if summary:
             self.context.progress_reporter.warn(summary)
 
-        post_title = post.title
-        if len(post_title) == 0:
-            post_title = f'No title (id_{post.id[:8]})'
-
-        post_name = f'{post.created_at.date()} - {post_title}'
-        post_name = sanitize_string(post_name).replace('.', '').strip()
+        post_name = compose_post_directory_name(post.title, post.created_at, post.id)
 
         try:
             await DownloadSinglePostUseCase(

--- a/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
+++ b/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
@@ -12,6 +12,15 @@ from typing import Any, ClassVar, cast
 from yt_dlp.YoutubeDL import YoutubeDL
 from yt_dlp.utils import DownloadError
 
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    MAX_NAME_BYTES,
+    sanitize_filename,
+)
+
+# yt-dlp appends the real extension to the template ('.webm', '.mp4', ...):
+# the title byte budget leaves room for it.
+_EXTENSION_RESERVE_BYTES = 8
+
 YtDlOptions = dict[str, Any]
 ExternalVideoDownloadProgressHook = Callable[['ExternalVideoDownloadStatus'], None]
 
@@ -155,8 +164,11 @@ class ExternalVideosDownloader:
 
     @staticmethod
     def _sanitize_title(text: str) -> str:
-        # Cross-platform safe subset.
-        return ''.join(ch for ch in text if ch.isalnum() or ch == ' ')
+        # Cross-platform safe subset, capped so the appended extension fits.
+        safe = ''.join(ch for ch in text if ch.isalnum() or ch == ' ')
+        return sanitize_filename(
+            safe, max_bytes=MAX_NAME_BYTES - _EXTENSION_RESERVE_BYTES
+        )
 
     @staticmethod
     def _build_outtmpl(destination_directory: Path, title: str) -> str:

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -6,13 +6,14 @@ import http
 import mimetypes
 from asyncio import CancelledError
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 import aiofiles
 from aiohttp import ClientConnectionError, ClientPayloadError
 
 from boosty_downloader.src.infrastructure.path_sanitizer import (
-    sanitize_string,
+    sanitize_filename,
 )
 
 if TYPE_CHECKING:
@@ -116,6 +117,18 @@ class DownloadUnexpectedStatusError(DownloadError):
         self.response_message = response_message
 
 
+def _app_built_filename(name: str, guessed_ext: str | None) -> str:
+    """App-built names (videos, images): the guessed extension is glued on."""
+    return sanitize_filename(name, suffix=guessed_ext or '')
+
+
+def _author_filename(name: str) -> str:
+    """Truncate an author-given name; its own extension always survives."""
+    pure = PurePath(name)
+    ext = pure.suffix
+    return sanitize_filename(pure.stem, suffix=sanitize_filename(ext) if ext else '')
+
+
 def _extension_to_append(content_type: str | None) -> str | None:
     """
     Pick an extension for a name that has none by construction.
@@ -141,13 +154,13 @@ async def download_file(
                 response_message=response.reason or 'No reason provided',
             )
 
-        filename = sanitize_string(dl_config.filename)
-        file_path = dl_config.destination / filename
-
         if dl_config.guess_extension:
-            ext = _extension_to_append(response.content_type)
-            if ext is not None:
-                file_path = file_path.with_name(file_path.name + ext)
+            filename = _app_built_filename(
+                dl_config.filename, _extension_to_append(response.content_type)
+            )
+        else:
+            filename = _author_filename(dl_config.filename)
+        file_path = dl_config.destination / filename
 
         total_downloaded = 0
 

--- a/boosty_downloader/src/infrastructure/path_sanitizer.py
+++ b/boosty_downloader/src/infrastructure/path_sanitizer.py
@@ -19,13 +19,6 @@ _RESERVED_NAMES = frozenset(
 )
 
 
-def sanitize_string(string: str) -> str:
-    """Remove unsafe filesystem characters from a string"""
-    # Convert path to a string and sanitize it
-    unsafe_chars = r'[<>:"/\\|?*]'
-    return re.sub(unsafe_chars, '', str(string))
-
-
 def sanitize_filename(
     name: str,
     *,

--- a/boosty_downloader/src/infrastructure/path_sanitizer.py
+++ b/boosty_downloader/src/infrastructure/path_sanitizer.py
@@ -1,5 +1,6 @@
 """Filesystem-safe names: one policy for every directory and file we create."""
 
+import errno
 import re
 import unicodedata
 
@@ -17,6 +18,29 @@ _RESERVED_NAMES = frozenset(
     | {f'COM{i}' for i in range(1, 10)}
     | {f'LPT{i}' for i in range(1, 10)}
 )
+
+# Windows raises this instead of ENAMETOOLONG when the whole path
+# exceeds MAX_PATH (260 units by default).
+_WINERROR_PATH_TOO_LONG = 206
+
+# Generated names always fit the per-name limit, so this error means
+# the user's destination directory is too deep.
+PATH_TOO_LONG_HINT = (
+    'the full path exceeded the OS limit - '
+    'move the destination folder closer to the drive root'
+)
+
+
+def is_path_too_long_error(error: BaseException | None) -> bool:
+    """Check the error or any of its causes for the OS path-length failure."""
+    while error is not None:
+        if isinstance(error, OSError) and (
+            error.errno == errno.ENAMETOOLONG
+            or getattr(error, 'winerror', None) == _WINERROR_PATH_TOO_LONG
+        ):
+            return True
+        error = error.__cause__
+    return False
 
 
 def sanitize_filename(

--- a/boosty_downloader/src/infrastructure/path_sanitizer.py
+++ b/boosty_downloader/src/infrastructure/path_sanitizer.py
@@ -1,6 +1,22 @@
-"""The modules helps with path sanitization to make it work on different platforms"""
+"""Filesystem-safe names: one policy for every directory and file we create."""
 
 import re
+import unicodedata
+
+# Byte budget for one path component: ext4/APFS allow 255 bytes,
+# NTFS 255 UTF-16 chars; 240 leaves headroom on every platform.
+MAX_NAME_BYTES = 240
+
+# <>:"/\|?* are forbidden on Windows; control chars (newlines, tabs)
+# are forbidden there too and unreadable everywhere else.
+_UNSAFE_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f\x7f]')
+
+# Windows refuses these base names even with an extension (CON.txt).
+_RESERVED_NAMES = frozenset(
+    {'CON', 'PRN', 'AUX', 'NUL'}
+    | {f'COM{i}' for i in range(1, 10)}
+    | {f'LPT{i}' for i in range(1, 10)}
+)
 
 
 def sanitize_string(string: str) -> str:
@@ -8,3 +24,36 @@ def sanitize_string(string: str) -> str:
     # Convert path to a string and sanitize it
     unsafe_chars = r'[<>:"/\\|?*]'
     return re.sub(unsafe_chars, '', str(string))
+
+
+def sanitize_filename(
+    name: str,
+    *,
+    suffix: str = '',
+    max_bytes: int = MAX_NAME_BYTES,
+) -> str:
+    """
+    Turn arbitrary text into a name safe for every supported filesystem.
+
+    `suffix` is a caller-owned tail (a file extension or a dedup marker
+    like ' (a2dd6942)') that survives verbatim: only `name` is cleaned
+    and byte-truncated so the whole result fits `max_bytes`.
+    """
+    cleaned = unicodedata.normalize('NFC', name)
+    cleaned = _UNSAFE_CHARS.sub('', cleaned)
+    cleaned = cleaned.strip().rstrip('. ')
+
+    budget = max(max_bytes - len(suffix.encode('utf-8')), 0)
+    encoded = cleaned.encode('utf-8')
+    if len(encoded) > budget:
+        # A byte cut may land inside a multi-byte char: ignore the tail.
+        cleaned = encoded[:budget].decode('utf-8', errors='ignore')
+        cleaned = cleaned.rstrip('. ')
+
+    if not cleaned:
+        cleaned = 'untitled'
+
+    result = cleaned + suffix
+    if result.split('.', 1)[0].upper() in _RESERVED_NAMES:
+        result = f'_{result}'
+    return result

--- a/docs/concepts/filesystem-path-limits.md
+++ b/docs/concepts/filesystem-path-limits.md
@@ -1,0 +1,70 @@
+# Filesystem path and name limits
+
+**Every path has two independent limits:**
+- one **name** is limited by the filesystem
+- the **whole path** - by the OS API. 
+
+**Systems count in different units:**
+- Linux in UTF-8 bytes
+- macOS and Windows in UTF-16 units:
+  - Latin letter = 1 unit = 1 byte
+  - Cyrillic = 1 unit = 2 bytes
+  - emoji = 2 units = 4 bytes.
+
+## Limits per system
+
+| System                             | One name         | In real letters: Latin / Cyrillic / emoji | Whole path                                 |
+| ---------------------------------- | ---------------- | ----------------------------------------- | ------------------------------------------ |
+| Linux (ext4, btrfs, xfs, f2fs)     | 255 UTF-8 bytes  | 255 / 127 / 63                            | 4096 bytes                                 |
+| Android / Termux                   | 255 UTF-8 bytes  | 255 / 127 / 63                            | 4096 bytes                                 |
+| macOS (APFS, HFS+)                 | 255 UTF-16 units | 255 / 255 / 127                           | 1024 bytes                                 |
+| Windows (NTFS)                     | 255 UTF-16 units | 255 / 255 / 127                           | 260 units; ~32 767 with `LongPathsEnabled` |
+| USB stick / SD card (exFAT, FAT32) | 255 UTF-16 units | 255 / 255 / 127                           | limit of the OS it is plugged into         |
+
+## Examples
+
+```
+━━━ Linux (ext4/btrfs/xfs/f2fs) ━━ name <= 255 bytes ━━ path <= 4096 bytes ━━━
+
+# name: 127 Cyrillic letters = 254 bytes -> fits
+✅ /home/alice/boosty/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя
+
+# name: 128 Cyrillic letters = 256 bytes -> Errno 36 File name too long
+❌ /home/alice/boosty/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя
+
+# name: 64 emoji = 256 bytes -> Errno 36
+❌ /home/alice/boosty/🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+━━━ macOS (APFS/HFS+) ━━ name <= 255 UTF-16 units ━━ path <= 1024 bytes ━━━
+
+# name: 255 Cyrillic letters = 255 units, 510 bytes -> fits here, dies on Linux
+✅ /Users/alice/boosty/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя
+
+# name: a + 127 emoji = 255 units, 509 bytes -> fits
+✅ /Users/alice/boosty/a🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+# name: aa + 127 emoji = 256 units, 510 bytes -> Errno 63: the counter is units, not bytes
+❌ /Users/alice/boosty/aa🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+# every name is 200 bytes and legal, the whole path is 1225 bytes > 1024 -> Errno 63
+❌ /Users/alice/boosty/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя/яяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяяя
+
+━━━ Windows (NTFS) ━━ name <= 255 units ━━ path <= 260 units by default ━━━
+
+# path: 55 units total -> fits
+✅ C:\Boosty\2026-08-14 - Стрим (a2dd6942)\files\отчёт.pdf
+
+# name: 128 emoji = 256 units > 255 -> WinError 206, even with long paths enabled
+❌ C:\Boosty\🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
+
+# both names are legal (120 and 115 units), the whole path is 281 units > 260 -> WinError 206
+❌ C:\Users\alice\Downloads\boosty\author\Огромный стрим о жизни канала, ответы на вопросы подписчиков, планы на будущее и розыгрыш призов среди всех зрителей эфи\files\Огромный стрим о жизни канала, ответы на вопросы подписчиков, планы на будущее и розыгрыш призов среди всех зри.pdf
+
+# the same path after LongPathsEnabled = 1 (HKLM\SYSTEM\CurrentControlSet\Control\FileSystem): the limit becomes ~32 767 units
+✅ C:\Users\alice\Downloads\boosty\author\Огромный стрим о жизни канала, ответы на вопросы подписчиков, планы на будущее и розыгрыш призов среди всех зрителей эфи\files\Огромный стрим о жизни канала, ответы на вопросы подписчиков, планы на будущее и розыгрыш призов среди всех зри.pdf
+```
+
+What boosty-downloader relies on: 
+- every generated name is capped at `MAX_NAME_BYTES = 240` bytes (`path_sanitizer.py`)
+- characters <= UTF-16 units <= UTF-8 bytes for any text, so 240 bytes fits every system above with headroom
+- The full-path limit stays on the user: on default Windows keep the destination short (`C:\Boosty`) or enable `LongPathsEnabled`.

--- a/test/unit/external_videos_downloader/title_limit_test.py
+++ b/test/unit/external_videos_downloader/title_limit_test.py
@@ -1,0 +1,29 @@
+"""yt-dlp writes '<title>.<ext>' to disk - the title must leave room for both."""
+
+from __future__ import annotations
+
+from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+    ExternalVideosDownloader,
+)
+from boosty_downloader.src.infrastructure.path_sanitizer import MAX_NAME_BYTES
+
+
+def test_long_title_leaves_room_for_the_extension() -> None:
+    """#93: a long video title used to overflow the FS name limit via yt-dlp."""
+    title = ExternalVideosDownloader._sanitize_title('я' * 300)  # noqa: SLF001
+
+    assert len(title.encode('utf-8')) <= MAX_NAME_BYTES - len('.webm')
+
+
+def test_short_title_keeps_its_safe_subset_policy() -> None:
+    """Over-cutting would rename existing videos and break old post.html links."""
+    title = ExternalVideosDownloader._sanitize_title('My stream: part 2!')  # noqa: SLF001
+
+    assert title == 'My stream part 2'
+
+
+def test_emoji_only_title_falls_back_instead_of_a_hidden_file() -> None:
+    """An all-emoji title left an empty name: '.mp4' is a hidden file on Unix."""
+    title = ExternalVideosDownloader._sanitize_title('🔥🔥🔥')  # noqa: SLF001
+
+    assert title == 'untitled'

--- a/test/unit/file_downloader/filename_truncation_test.py
+++ b/test/unit/file_downloader/filename_truncation_test.py
@@ -1,0 +1,42 @@
+"""Long file names (#93) must not lose what makes them openable or unique."""
+
+from __future__ import annotations
+
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    _boosty_video_filename,
+)
+from boosty_downloader.src.domain.post import PostDataChunkBoostyVideo
+from boosty_downloader.src.infrastructure.file_downloader import (
+    _app_built_filename,
+    _author_filename,
+)
+from boosty_downloader.src.infrastructure.path_sanitizer import MAX_NAME_BYTES
+
+
+def test_author_extension_survives_truncation() -> None:
+    """A truncated 'архив...zip' without .zip is a file nothing can open."""
+    name = _author_filename('я' * 300 + '.zip')
+
+    assert name.endswith('.zip')
+    assert len(name.encode('utf-8')) <= MAX_NAME_BYTES
+
+
+def test_author_name_stays_intact_when_short() -> None:
+    """#75 regression guard: author names must never be rewritten."""
+    assert _author_filename('any.appimage') == 'any.appimage'
+
+
+def test_app_built_name_gets_the_guessed_extension() -> None:
+    assert _app_built_filename('clip (a2dd6942)', '.mp4') == 'clip (a2dd6942).mp4'
+
+
+def test_long_video_title_keeps_id_and_extension() -> None:
+    """Truncation must eat neither the dedup id (#104) nor the extension."""
+    video = PostDataChunkBoostyVideo(
+        id='a2dd6942-full', title='я' * 300, url='u', quality='medium'
+    )
+
+    name = _app_built_filename(_boosty_video_filename(video), '.mp4')
+
+    assert name.endswith(' (a2dd6942).mp4')
+    assert len(name.encode('utf-8')) <= MAX_NAME_BYTES

--- a/test/unit/path_sanitizer/path_sanitizer_test.py
+++ b/test/unit/path_sanitizer/path_sanitizer_test.py
@@ -1,0 +1,82 @@
+"""Post titles become directory and file names - the OS must accept them."""
+
+from __future__ import annotations
+
+import pytest
+
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    MAX_NAME_BYTES,
+    sanitize_filename,
+)
+
+
+def test_long_cyrillic_title_fits_the_byte_limit() -> None:
+    """#93: 130 Cyrillic chars are 260 bytes - over the 255-byte FS limit."""
+    result = sanitize_filename('я' * 130)
+
+    assert len(result.encode('utf-8')) <= MAX_NAME_BYTES
+
+
+def test_truncation_keeps_the_dedup_suffix() -> None:
+    """Truncating the tail would eat the post id and revive #104 collisions."""
+    result = sanitize_filename('я' * 300, suffix=' (a2dd6942)')
+
+    assert result.endswith(' (a2dd6942)')
+    assert len(result.encode('utf-8')) <= MAX_NAME_BYTES
+
+
+def test_truncation_keeps_the_extension() -> None:
+    """A long author filename must stay openable: archive.zip, not a stub."""
+    result = sanitize_filename('я' * 300, suffix='.zip')
+
+    assert result.endswith('.zip')
+    assert len(result.encode('utf-8')) <= MAX_NAME_BYTES
+
+
+def test_truncation_never_splits_a_multibyte_char() -> None:
+    """A cut inside an emoji would leave invalid UTF-8 the OS rejects."""
+    result = sanitize_filename('🔥🔥🔥', max_bytes=10)
+
+    assert result == '🔥🔥'
+
+
+def test_newlines_and_control_chars_are_removed() -> None:
+    """The PR #86 repro title has newlines - illegal on Windows."""
+    result = sanitize_filename('Первая строка\nвторая\tи ещё')
+
+    assert '\n' not in result
+    assert '\t' not in result
+
+
+@pytest.mark.parametrize(
+    ('name', 'suffix', 'expected'),
+    [
+        ('CON', '.txt', '_CON.txt'),
+        ('nul', '', '_nul'),
+    ],
+)
+def test_windows_reserved_name_gets_a_prefix(
+    name: str, suffix: str, expected: str
+) -> None:
+    """Windows refuses CON/NUL even with an extension - the file never saves."""
+    assert sanitize_filename(name, suffix=suffix) == expected
+
+
+def test_trailing_dots_and_spaces_are_stripped() -> None:
+    """Windows silently drops them, so the name on disk differs from links."""
+    assert sanitize_filename('Название поста... ') == 'Название поста'
+
+
+def test_empty_result_falls_back_to_placeholder() -> None:
+    """A title of pure unsafe chars would give Path('') and crash mkdir."""
+    assert sanitize_filename('???***') == 'untitled'
+
+
+def test_decomposed_unicode_is_normalized_to_nfc() -> None:
+    """macOS gives decomposed names; NFC keeps names identical across OSes."""
+    assert sanitize_filename('\u0438\u0306') == '\u0439'
+
+
+def test_normal_title_is_unchanged() -> None:
+    """Over-cutting would rename every existing folder and re-download all."""
+    assert sanitize_filename('My post 2.0 (final)') == 'My post 2.0 (final)'

--- a/test/unit/path_sanitizer/path_too_long_error_test.py
+++ b/test/unit/path_sanitizer/path_too_long_error_test.py
@@ -1,0 +1,42 @@
+"""The path-length hint must fire on the real OS error and only on it."""
+
+from __future__ import annotations
+
+import errno
+
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    is_path_too_long_error,
+)
+
+
+def test_detects_the_posix_name_too_long_error() -> None:
+    """Missing the errno means the user gets a raw OSError with no advice."""
+    error = OSError(errno.ENAMETOOLONG, 'File name too long')
+
+    assert is_path_too_long_error(error)
+
+
+def test_detects_the_error_hidden_under_wrappers() -> None:
+    """The OSError reaches the reporter wrapped into app errors via 'from e'."""
+    cause = OSError(errno.ENAMETOOLONG, 'File name too long')
+    wrapper = RuntimeError('download failed')
+    wrapper.__cause__ = ValueError('io failed')
+    wrapper.__cause__.__cause__ = cause
+
+    assert is_path_too_long_error(wrapper)
+
+
+def test_detects_the_windows_path_error_by_winerror() -> None:
+    """Windows reports MAX_PATH overflow as WinError 206, not ENAMETOOLONG."""
+
+    class _WindowsPathError(OSError):
+        winerror = 206
+
+    assert is_path_too_long_error(_WindowsPathError())
+
+
+def test_ignores_unrelated_errors() -> None:
+    """A false hint would send the user chasing folders for a network problem."""
+    assert not is_path_too_long_error(OSError(errno.ENOENT, 'No such file'))
+    assert not is_path_too_long_error(RuntimeError('boom'))
+    assert not is_path_too_long_error(None)

--- a/test/unit/use_cases/download_all_posts_test.py
+++ b/test/unit/use_cases/download_all_posts_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -175,6 +176,23 @@ async def test_unexpected_error_skips_the_post_and_the_run_continues(
     summary = reporter.warnings[-1]
     assert 'failed to download' in summary
     assert 'post p1' in summary
+
+
+@pytest.mark.asyncio
+async def test_path_too_long_error_carries_the_folder_hint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bare 'File name too long' leaves the user without a way out (#93)."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    error = OSError(errno.ENAMETOOLONG, 'File name too long')
+    _script_outcomes(monkeypatch, {'p1': error})
+
+    await _use_case(['p1'], reporter, failed_logger).execute()
+
+    hint = 'move the destination folder closer to the drive root'
+    assert any(hint in message for message in reporter.errors)
+    assert any(hint in message for _, message in failed_logger.entries)
 
 
 @pytest.mark.asyncio

--- a/test/unit/use_cases/post_directory_name_test.py
+++ b/test/unit/use_cases/post_directory_name_test.py
@@ -1,0 +1,42 @@
+"""Post folder names must fit the FS byte limit without losing the dedup id."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    compose_post_directory_name,
+)
+
+CREATED_AT = datetime(2026, 8, 14, 12, 0, tzinfo=timezone.utc)
+
+
+def test_long_cyrillic_title_folder_fits_the_byte_limit() -> None:
+    """#93: a long Cyrillic title used to crash mkdir with File name too long."""
+    name = compose_post_directory_name('я' * 300, CREATED_AT, 'a2dd6942-full-uuid')
+
+    assert len(name.encode('utf-8')) <= 240
+    assert name.startswith('2026-08-14 - ')
+    assert name.endswith(' (a2dd6942)')
+
+
+def test_same_long_title_posts_get_distinct_folders() -> None:
+    """Truncation must not eat the id tail, or same-titled posts collide (#104)."""
+    first = compose_post_directory_name('я' * 300, CREATED_AT, 'a2dd6942-first')
+    second = compose_post_directory_name('я' * 300, CREATED_AT, 'b3ee7053-second')
+
+    assert first != second
+
+
+def test_dots_in_title_survive() -> None:
+    """The old .replace('.', '') hack mangled titles: 'v2.0' became 'v20'."""
+    name = compose_post_directory_name('Release v2.0', CREATED_AT, 'a2dd6942-x')
+
+    assert name == '2026-08-14 - Release v2.0 (a2dd6942)'
+
+
+def test_empty_title_falls_back_to_a_readable_name() -> None:
+    """An untitled post must still get a folder, not Path('') and a crash."""
+    name = compose_post_directory_name('', CREATED_AT, 'a2dd6942-x')
+
+    assert name == '2026-08-14 - No title (a2dd6942)'


### PR DESCRIPTION
Closes #93

## Summary

Long post titles crashed the download with `OSError: File name too long`. Filesystems cap one name at 255 bytes, and Cyrillic takes 2 bytes per letter in UTF-8 - so a title of 128 Russian letters was already over the limit. Now every name the app generates is cut to a 240-byte budget, and the parts that matter - the post date, the dedup id and the file extension - always survive the cut.

## Problem

- Post folders, file names and yt-dlp video names were built from titles with no length limit at all
- The old sanitizer only removed `<>:"/\|?*`; newlines from real post titles stayed in folder names (illegal on Windows), and a title of pure emoji produced a hidden file like `.mp4`
- The community fix (PR #86) truncated the composed string from the end - that would eat the `(id8)` dedup tail and file extensions, reviving #104 and #75
- Two download paths named the same post differently: `download` added `(id8)`, `--post-url` did not
- The `.replace('.', '')` hack mangled titles: "v2.0" became "v20"

## Fix

- One policy function `sanitize_filename(name, suffix, max_bytes)`: NFC normalization, control chars and unsafe chars removed, trailing dots and spaces stripped, Windows reserved names prefixed, byte truncation that never splits a UTF-8 char - and a `suffix` (extension or dedup id) that never gets truncated away
- Both download paths compose the folder as `date - title (id8)` through one helper; only the title part is ever cut
- Author file names are cut by the stem, their own extension survives; app-built names reserve room for the guessed extension
- External video titles leave room for the extension yt-dlp appends
- When the full path is still too long for the OS (deep destination folder), the error message now advises moving the destination closer to the drive root - the detector recognizes `ENAMETOOLONG` and Windows `WinError 206` even under error wrappers
- `docs/concepts/filesystem-path-limits.md`: a practical reference of per-system limits, with real paths that fit and fail

## Before / After

**Before:** a post titled with 130 Cyrillic letters fails on Linux with a raw `OSError: [Errno 36] File name too long`, lands in the failed log with no advice, and the same post gets different folders via `download` and `--post-url`.
**After:** the folder is `2026-08-14 - яяя...я (a2dd6942)` at 240 bytes, both paths agree on it, `archive.zip` cut from a long title still ends with `.zip`, and a genuine path-length error tells the user what to do.

## Compatibility

- Existing downloads are untouched: the cache stores only post uuids and flags, never paths; folders are never renamed or deleted
- A new-style folder name appears only when an updated post is re-downloaded; unchanged cached posts are skipped exactly as before

## Verification

- Live on APFS: the #93 repro (`'я' * 300` as a title) fails `mkdir` with a raw name and succeeds with the composed one at exactly 240 bytes with the id tail intact
- Live probing also pinned the real APFS limit: 255 UTF-16 units, not bytes or characters - documented in the new reference
- The path-length detector fires on a real FS error (`errno 63`) and stays silent on unrelated errors
- 29 new unit tests across the sanitizer, folder composition, file truncation, video titles and the error hint; the #104 and #75 regression tests pass unchanged; 100 tests total
- `task check` (ruff, format, pyright) and `task build` green

## Notes

- eCryptfs (143-byte names) is knowingly out of support
- The full-path limit (Windows 260 by default) cannot be fixed by a name budget - the user picks the base folder; the error hint plus the docs reference cover it
- Found during verification: on POSIX a destination deeper than ~490 bytes breaks the SQLite cache first (its own 512-byte path limit) with a misleading "cache outdated" message - exotic, noted for a possible follow-up