### PR TITLE
[debug-log] Log request outcomes, connection phases and retry attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Added
+
+- Debug log now tells what happened to every request, not only that it started: outcome lines with status and timing (`-> 200 in 0.31s`) or the error chain (`-> FAIL ClientConnectorError <- ConnectionResetError in 12.1s`), dns/connect phase timings, retry attempt numbers (`attempt 2/5`), and a live `connecting...` line - a hang or a killed handshake is readable straight from the log
+
 ### Fixed
 
 - Long post titles no longer crash the download with "File name too long" (#93, #88): folder and file names are cut to fit the filesystem limit, and the post date, the dedup id and the file extension always survive the cut

--- a/boosty_downloader/src/application/di/app_environment.py
+++ b/boosty_downloader/src/application/di/app_environment.py
@@ -78,7 +78,11 @@ class AppEnvironment:
                 # - sock_read: max quiet time between received chunks
                 timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=90),
                 trust_env=True,
-                trace_configs=[create_request_trace_config()],
+                trace_configs=[
+                    create_request_trace_config(
+                        total_attempts=self.retry_options.attempts
+                    )
+                ],
             )
         )
 

--- a/boosty_downloader/src/infrastructure/loggers/request_tracing.py
+++ b/boosty_downloader/src/infrastructure/loggers/request_tracing.py
@@ -2,12 +2,16 @@
 Session-level observer that records every outgoing request in the debug log.
 
 Attached to the shared ClientSession, so API calls, file downloads and
-retries all leave a line - the callers never know the log exists.
+retries all leave lines - the callers never know the log exists. Each
+request logs its start, the live connection phase and the outcome, so a
+hang or a killed handshake is readable straight from the log.
 """
 
 from __future__ import annotations
 
 import logging
+from itertools import count
+from time import monotonic
 from typing import TYPE_CHECKING
 from urllib.parse import parse_qsl, urlsplit
 
@@ -16,9 +20,23 @@ from aiohttp import TraceConfig
 if TYPE_CHECKING:
     from types import SimpleNamespace
 
-    from aiohttp import ClientSession, TraceRequestStartParams
+    from aiohttp import (
+        ClientSession,
+        TraceConnectionCreateEndParams,
+        TraceConnectionCreateStartParams,
+        TraceConnectionReuseconnParams,
+        TraceDnsResolveHostEndParams,
+        TraceDnsResolveHostStartParams,
+        TraceRequestEndParams,
+        TraceRequestExceptionParams,
+        TraceRequestStartParams,
+    )
 
 _log = logging.getLogger(__name__)
+
+# Concurrent requests interleave in the log; the id ties one request's
+# start, connection and outcome lines together.
+_request_ids = count(1)
 
 
 def redacted_url(url: str) -> str:
@@ -38,16 +56,139 @@ def redacted_url(url: str) -> str:
     return f'{base}?{masked_query}'
 
 
+# Deeper causes add noise, not diagnosis: three levels cover the real
+# wrappers (app error -> client error -> OS error).
+_MAX_CAUSE_DEPTH = 3
+
+
+def _error_chain(error: BaseException) -> str:
+    """Name the error and up to two of its causes: the chain is the diagnosis."""
+    names: list[str] = []
+    current: BaseException | None = error
+    while current is not None and len(names) < _MAX_CAUSE_DEPTH:
+        names.append(type(current).__name__)
+        current = current.__cause__
+    return ' <- '.join(names)
+
+
+def _phases(ctx: SimpleNamespace) -> str:
+    """
+    Summarize the connection phases collected during the request.
+
+    A phase that never finished is timed up to now: a request that died
+    mid-connect reports how long the connect lasted.
+    """
+    if getattr(ctx, 'conn_reused', False):
+        return 'conn reused'
+    parts: list[str] = []
+    dns_time = getattr(ctx, 'dns_time', None)
+    dns_started = getattr(ctx, 'dns_started', None)
+    conn_started = getattr(ctx, 'conn_started', None)
+    if dns_time is not None:
+        parts.append(f'dns {dns_time:.3f}s')
+    elif dns_started is not None:
+        parts.append(f'dns {monotonic() - dns_started:.3f}s')
+    elif conn_started is not None:
+        parts.append('dns cache')
+    if conn_started is not None:
+        conn_time = getattr(ctx, 'conn_time', None)
+        if conn_time is None:
+            conn_time = monotonic() - conn_started
+        parts.append(f'conn {conn_time:.3f}s')
+    return ', '.join(parts)
+
+
 async def _log_request_start(
     _session: ClientSession,
-    _ctx: SimpleNamespace,
+    ctx: SimpleNamespace,
     params: TraceRequestStartParams,
 ) -> None:
-    _log.debug('%s %s', params.method, redacted_url(str(params.url)))
+    ctx.req_id = next(_request_ids)
+    ctx.started = monotonic()
+    _log.debug('#%d %s %s', ctx.req_id, params.method, redacted_url(str(params.url)))
+
+
+async def _log_connection_start(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    _params: TraceConnectionCreateStartParams,
+) -> None:
+    # The live marker: while a connect hangs, this stays the last line.
+    ctx.conn_started = monotonic()
+    _log.debug('#%d connecting...', ctx.req_id)
+
+
+async def _mark_connection_end(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    _params: TraceConnectionCreateEndParams,
+) -> None:
+    ctx.conn_time = monotonic() - ctx.conn_started
+
+
+async def _mark_connection_reused(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    _params: TraceConnectionReuseconnParams,
+) -> None:
+    ctx.conn_reused = True
+
+
+async def _mark_dns_start(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    _params: TraceDnsResolveHostStartParams,
+) -> None:
+    ctx.dns_started = monotonic()
+
+
+async def _mark_dns_end(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    _params: TraceDnsResolveHostEndParams,
+) -> None:
+    ctx.dns_time = monotonic() - ctx.dns_started
+
+
+async def _log_request_end(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    params: TraceRequestEndParams,
+) -> None:
+    elapsed = monotonic() - ctx.started
+    phases = _phases(ctx)
+    suffix = f' ({phases})' if phases else ''
+    _log.debug(
+        '#%d -> %d in %.2fs%s', ctx.req_id, params.response.status, elapsed, suffix
+    )
+
+
+async def _log_request_exception(
+    _session: ClientSession,
+    ctx: SimpleNamespace,
+    params: TraceRequestExceptionParams,
+) -> None:
+    elapsed = monotonic() - ctx.started
+    phases = _phases(ctx)
+    suffix = f' ({phases})' if phases else ''
+    _log.debug(
+        '#%d -> FAIL %s in %.2fs%s',
+        ctx.req_id,
+        _error_chain(params.exception),
+        elapsed,
+        suffix,
+    )
 
 
 def create_request_trace_config() -> TraceConfig:
     """Build the request observer to attach to the ClientSession."""
     trace_config = TraceConfig()
     trace_config.on_request_start.append(_log_request_start)
+    trace_config.on_connection_create_start.append(_log_connection_start)
+    trace_config.on_connection_create_end.append(_mark_connection_end)
+    trace_config.on_connection_reuseconn.append(_mark_connection_reused)
+    trace_config.on_dns_resolvehost_start.append(_mark_dns_start)
+    trace_config.on_dns_resolvehost_end.append(_mark_dns_end)
+    trace_config.on_request_end.append(_log_request_end)
+    trace_config.on_request_exception.append(_log_request_exception)
     return trace_config

--- a/boosty_downloader/src/infrastructure/loggers/request_tracing.py
+++ b/boosty_downloader/src/infrastructure/loggers/request_tracing.py
@@ -10,16 +10,16 @@ hang or a killed handshake is readable straight from the log.
 from __future__ import annotations
 
 import logging
+from functools import partial
 from itertools import count
 from time import monotonic
-from typing import TYPE_CHECKING
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
 from urllib.parse import parse_qsl, urlsplit
 
 from aiohttp import TraceConfig
 
 if TYPE_CHECKING:
-    from types import SimpleNamespace
-
     from aiohttp import (
         ClientSession,
         TraceConnectionCreateEndParams,
@@ -98,6 +98,18 @@ def _phases(ctx: SimpleNamespace) -> str:
     return ', '.join(parts)
 
 
+def _attempt_label(ctx: SimpleNamespace) -> str:
+    """Format the retry attempt mark for requests made through RetryClient."""
+    request_ctx = getattr(ctx, 'trace_request_ctx', None)
+    if not isinstance(request_ctx, dict):
+        return ''
+    attempt = cast('dict[str, object]', request_ctx).get('current_attempt')
+    if not isinstance(attempt, int):
+        return ''
+    total = getattr(ctx, 'total_attempts', None)
+    return f' (attempt {attempt}/{total})' if total else f' (attempt {attempt})'
+
+
 async def _log_request_start(
     _session: ClientSession,
     ctx: SimpleNamespace,
@@ -105,7 +117,13 @@ async def _log_request_start(
 ) -> None:
     ctx.req_id = next(_request_ids)
     ctx.started = monotonic()
-    _log.debug('#%d %s %s', ctx.req_id, params.method, redacted_url(str(params.url)))
+    _log.debug(
+        '#%d %s %s%s',
+        ctx.req_id,
+        params.method,
+        redacted_url(str(params.url)),
+        _attempt_label(ctx),
+    )
 
 
 async def _log_connection_start(
@@ -180,9 +198,18 @@ async def _log_request_exception(
     )
 
 
-def create_request_trace_config() -> TraceConfig:
-    """Build the request observer to attach to the ClientSession."""
-    trace_config = TraceConfig()
+def create_request_trace_config(total_attempts: int | None = None) -> TraceConfig:
+    """
+    Build the request observer to attach to the ClientSession.
+
+    `total_attempts` is the retry budget: with it the start line reads
+    'attempt 2/5' instead of a bare 'attempt 2'.
+    """
+    # Every per-request ctx is born knowing the retry budget.
+    ctx_factory = partial(SimpleNamespace, total_attempts=total_attempts)
+    trace_config = TraceConfig(
+        trace_config_ctx_factory=cast('type[SimpleNamespace]', ctx_factory)
+    )
     trace_config.on_request_start.append(_log_request_start)
     trace_config.on_connection_create_start.append(_log_connection_start)
     trace_config.on_connection_create_end.append(_mark_connection_end)

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,7 +24,8 @@ lint.ignore = [
 # S101: pytest is built on assert
 # PLR2004: magic numbers are fine in test assertions
 # INP001: test dir is not a package, no __init__.py needed
-"test/*" = ["D", "ANN201", "S101", "PLR2004", "INP001"]
+# SLF001: tests exercise private helpers directly
+"test/*" = ["D", "ANN201", "S101", "PLR2004", "INP001", "SLF001"]
 # T201: dev scripts may use print()
 # INP001: scripts dir is not a package
 # S603: subprocess with fixed args in trusted dev scripts

--- a/test/unit/external_videos_downloader/title_limit_test.py
+++ b/test/unit/external_videos_downloader/title_limit_test.py
@@ -10,20 +10,20 @@ from boosty_downloader.src.infrastructure.path_sanitizer import MAX_NAME_BYTES
 
 def test_long_title_leaves_room_for_the_extension() -> None:
     """#93: a long video title used to overflow the FS name limit via yt-dlp."""
-    title = ExternalVideosDownloader._sanitize_title('я' * 300)  # noqa: SLF001
+    title = ExternalVideosDownloader._sanitize_title('я' * 300)
 
     assert len(title.encode('utf-8')) <= MAX_NAME_BYTES - len('.webm')
 
 
 def test_short_title_keeps_its_safe_subset_policy() -> None:
     """Over-cutting would rename existing videos and break old post.html links."""
-    title = ExternalVideosDownloader._sanitize_title('My stream: part 2!')  # noqa: SLF001
+    title = ExternalVideosDownloader._sanitize_title('My stream: part 2!')
 
     assert title == 'My stream part 2'
 
 
 def test_emoji_only_title_falls_back_instead_of_a_hidden_file() -> None:
     """An all-emoji title left an empty name: '.mp4' is a hidden file on Unix."""
-    title = ExternalVideosDownloader._sanitize_title('🔥🔥🔥')  # noqa: SLF001
+    title = ExternalVideosDownloader._sanitize_title('🔥🔥🔥')
 
     assert title == 'untitled'

--- a/test/unit/loggers/request_tracing_test.py
+++ b/test/unit/loggers/request_tracing_test.py
@@ -59,7 +59,7 @@ def test_success_outcome_shows_status_timing_and_phases(
 def test_failed_attempt_names_the_error_chain(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The night incident: a reset handshake must be readable from the log."""
+    """A TLS handshake reset by the network must be readable from the log."""
     caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
     ctx = SimpleNamespace(trace_request_ctx=None)
     error = ConnectionError('cannot connect')
@@ -81,7 +81,7 @@ def test_failed_attempt_names_the_error_chain(
 def test_hang_leaves_connecting_as_the_last_line(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A hard hang used to leave the log silent - now the phase is visible live."""
+    """During a hang the last log line must name the stuck phase."""
     caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
     ctx = SimpleNamespace(trace_request_ctx=None)
 
@@ -127,6 +127,30 @@ def test_request_lines_share_one_id(caplog: pytest.LogCaptureFixture) -> None:
     ids = {message.split()[0] for message in caplog.messages}
     assert len(ids) == 1
     assert ids.pop().startswith('#')
+
+
+def test_retry_attempt_number_lands_in_the_start_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Silent retries hide that a request is dying: attempt 2/5 tells it."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx={'current_attempt': 2}, total_attempts=5)
+
+    _run_hooks(request_tracing._log_request_start(_SESSION, ctx, _start_params()))
+
+    assert caplog.messages[-1].endswith('(attempt 2/5)')
+
+
+def test_requests_without_retry_context_get_no_attempt_mark(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A request outside RetryClient must not invent attempt numbers."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+
+    _run_hooks(request_tracing._log_request_start(_SESSION, ctx, _start_params()))
+
+    assert '(attempt' not in caplog.messages[-1]
 
 
 def test_redacted_url_masks_query_values_but_keeps_keys() -> None:

--- a/test/unit/loggers/request_tracing_test.py
+++ b/test/unit/loggers/request_tracing_test.py
@@ -1,8 +1,132 @@
-"""The debug log is attached to public issues - signed queries must not leak."""
+"""The debug log must tell what happened to a request, not only that it started."""
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+from boosty_downloader.src.infrastructure.loggers import request_tracing
 from boosty_downloader.src.infrastructure.loggers.request_tracing import redacted_url
+
+if TYPE_CHECKING:
+    import pytest
+    from aiohttp import ClientSession
+
+_LOGGER_NAME = request_tracing.__name__
+_SESSION = cast('ClientSession', None)
+
+
+def _run_hooks(*coros: object) -> None:
+    async def runner() -> None:
+        for coro in coros:
+            await coro  # type: ignore[misc]
+
+    asyncio.run(runner())
+
+
+def _start_params(
+    url: str = 'https://api.boosty.to/v1/blog/x/post/',
+) -> SimpleNamespace:
+    return SimpleNamespace(method='GET', url=url)
+
+
+def test_success_outcome_shows_status_timing_and_phases(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Without outcomes a slow Boosty looks the same as a dead one."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+
+    _run_hooks(
+        request_tracing._log_request_start(_SESSION, ctx, _start_params()),
+        request_tracing._log_connection_start(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._mark_dns_start(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._mark_dns_end(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._mark_connection_end(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._log_request_end(
+            _SESSION, ctx, SimpleNamespace(response=SimpleNamespace(status=200))
+        ),
+    )
+
+    outcome = caplog.messages[-1]
+    assert '-> 200 in' in outcome
+    assert 'dns' in outcome
+    assert 'conn' in outcome
+
+
+def test_failed_attempt_names_the_error_chain(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The night incident: a reset handshake must be readable from the log."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+    error = ConnectionError('cannot connect')
+    error.__cause__ = ConnectionResetError('handshake killed')
+
+    _run_hooks(
+        request_tracing._log_request_start(_SESSION, ctx, _start_params()),
+        request_tracing._log_connection_start(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._log_request_exception(
+            _SESSION, ctx, SimpleNamespace(exception=error)
+        ),
+    )
+
+    outcome = caplog.messages[-1]
+    assert 'FAIL ConnectionError <- ConnectionResetError' in outcome
+    assert 'conn' in outcome, 'the unfinished connect phase must still be timed'
+
+
+def test_hang_leaves_connecting_as_the_last_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A hard hang used to leave the log silent - now the phase is visible live."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+
+    _run_hooks(
+        request_tracing._log_request_start(_SESSION, ctx, _start_params()),
+        request_tracing._log_connection_start(_SESSION, ctx, SimpleNamespace()),
+    )
+
+    assert caplog.messages[-1].endswith('connecting...')
+
+
+def test_pooled_connection_is_marked_reused(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A reused connection must not pretend it measured dns and connect."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+
+    _run_hooks(
+        request_tracing._log_request_start(_SESSION, ctx, _start_params()),
+        request_tracing._mark_connection_reused(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._log_request_end(
+            _SESSION, ctx, SimpleNamespace(response=SimpleNamespace(status=200))
+        ),
+    )
+
+    assert '(conn reused)' in caplog.messages[-1]
+
+
+def test_request_lines_share_one_id(caplog: pytest.LogCaptureFixture) -> None:
+    """Concurrent requests interleave: without ids the lines are unmatchable."""
+    caplog.set_level(logging.DEBUG, logger=_LOGGER_NAME)
+    ctx = SimpleNamespace(trace_request_ctx=None)
+
+    _run_hooks(
+        request_tracing._log_request_start(_SESSION, ctx, _start_params()),
+        request_tracing._log_connection_start(_SESSION, ctx, SimpleNamespace()),
+        request_tracing._log_request_end(
+            _SESSION, ctx, SimpleNamespace(response=SimpleNamespace(status=200))
+        ),
+    )
+
+    ids = {message.split()[0] for message in caplog.messages}
+    assert len(ids) == 1
+    assert ids.pop().startswith('#')
 
 
 def test_redacted_url_masks_query_values_but_keeps_keys() -> None:


### PR DESCRIPTION
## Summary

The debug log used to record only that a request started. A hang or a killed connection left the log silent - diagnosing the recent network incident took manual raw requests. Now every request logs its outcome, its connection phases and its retry attempt number: the log answers "what happened and where it got stuck" by itself.

## Problem

- One request start line was the whole trace: no outcome, no timing, no error
- Retries were invisible: five failing attempts looked like five identical start lines with silent 13-second gaps
- During a hang the log had nothing to say at all - the failing phase (dns / connect / TLS) was anyone's guess

## Fix

- Every request gets a short id (`#N`) tying its lines together, an outcome line with status and timing (`-> 200 in 0.31s`) or the error chain (`-> FAIL ClientConnectorError <- ConnectionResetError in 12.1s`), and phase timings (`dns 0.123s, conn 1.043s`; pooled connections say `conn reused`)
- A live `connecting...` line marks the connection phase: while a connect hangs, it stays the last line of the log
- A phase that died mid-way reports how long it lasted - a 12-second tarpit is visible as `conn 12.0s` on the failed attempt
- Requests through the retry client are marked `(attempt 2/5)`; the budget comes from DI, requests outside the retry client get no mark
- URLs stay redacted exactly as before - outcome lines carry the request id instead of repeating the URL

## Before / After

**Before:** a killed TLS handshake looks like nothing: the same GET line repeats every ~13 seconds, the log never says why.
**After:**

```
#1 GET https://api.boosty.to/v1/blog/author/post/?limit=... (attempt 1/5)
#1 connecting...
#1 -> FAIL ClientConnectorError <- ConnectionResetError in 12.10s (dns 0.011s, conn 12.09s)
#2 GET https://api.boosty.to/v1/blog/author/post/?limit=... (attempt 2/5)
```

## Verification

- Live run of `--debug check` against the real API: start line with `(attempt 1/5)`, live `connecting...`, outcome `-> 200 in 1.64s (dns 0.123s, conn 1.043s)` - taken from the actual log file
- 9 unit tests on the tracing hooks: outcome with phases, error chain of a reset handshake, "last line is connecting" for hangs, pooled connections, shared request id, attempt marks present and absent
- Full `task ci` green: checks, 107 unit tests, 6 live integration tests, build