### PR TITLE
[release] Wizard polish: branch switching, tomllib, run link

### DIFF
--- a/docs/development/04-releasing.md
+++ b/docs/development/04-releasing.md
@@ -16,7 +16,7 @@ The section fills up during development: the 📝 Changelog CI job requires ever
 task release -- minor   # or: patch / major / X.Y.Z
 ```
 
-Start from `main` (the wizard fast-forwards it) or from an existing `release/vX.Y.Z` branch. Before touching anything the wizard verifies: `git` and `gh` present and authorized, clean tree (only `CHANGELOG.md` edits are allowed - they ride in the release commit), non-empty `## Unreleased`, the version is free on PyPI, the tag does not exist. Then it shows a preview panel and, after your confirmation:
+Start from `main` (the wizard fast-forwards it) or from an existing `release/vX.Y.Z` branch - on any other branch the wizard offers to switch to `main` itself (only when the tree is clean, so no local edits travel between branches). Before touching anything the wizard verifies: `git` and `gh` present and authorized, clean tree (only `CHANGELOG.md` edits are allowed - they ride in the release commit), non-empty `## Unreleased`, the version is free on PyPI, the tag does not exist. Then it shows a preview panel and, after your confirmation:
 
 - Creates `release/vX.Y.Z` (when starting from `main`)
 - Updates `version` in `pyproject.toml`
@@ -54,11 +54,10 @@ Wait for the CI checks, merge. The ruleset lets changes into main only through P
 ### 4. Tag the merge commit on main
 
 ```bash
-git checkout main
 task release:tag
 ```
 
-The wizard pulls fresh main, verifies the version, the changelog section and the tag, shows what will be tagged and pushes `vX.Y.Z` after confirmation. Tagging happens on fresh main because squash creates a new commit - your local release commit is not the one on main.
+The wizard offers to switch to `main` when you are still on another branch, pulls fresh main, verifies the version, the changelog section and the tag, shows what will be tagged and pushes `vX.Y.Z` after confirmation. After the push it prints the direct link to the workflow run it has just started (or the runs list, when GitHub is slow to spawn it). Tagging happens on fresh main because squash creates a new commit - your local release commit is not the one on main.
 
 ### 5. The workflow does the rest
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -3,17 +3,19 @@
 from __future__ import annotations
 
 import io
+import json
 import re
 import shlex
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn, TypeAlias
+from typing import TYPE_CHECKING, NoReturn, TypeAlias, cast
 
 import tomllib
 
@@ -450,6 +452,51 @@ def _check_main_ready() -> str:
     return version
 
 
+# GitHub spawns the run a few seconds after the tag push; each gh call
+# itself takes ~5s, so the window is tries x (sleep + call) = ~30s.
+_RUN_POLL_TRIES = 5
+_RUN_POLL_SECONDS = 2
+
+
+def _parse_runs(raw: str) -> list[dict[str, str]]:
+    """Parse `gh run list --json` output; anything malformed means no runs."""
+    try:
+        data: object = json.loads(raw)
+    except ValueError:
+        return []
+    if not isinstance(data, list):
+        return []
+    return [
+        cast('dict[str, str]', item)
+        for item in cast('list[object]', data)
+        if isinstance(item, dict)
+    ]
+
+
+def _release_run_url(tag: str) -> str:
+    """
+    Resolve the workflow run the tag push has started.
+
+    The run page shows the whole pipeline live; when the run does not
+    appear within the poll window, the workflow's runs list is the answer.
+    """
+    for attempt in range(_RUN_POLL_TRIES):
+        if attempt:
+            time.sleep(_RUN_POLL_SECONDS)
+        code, out = _try(
+            'gh', 'run', 'list',
+            '--workflow', 'release.yaml',
+            '--limit', '10',
+            '--json', 'headBranch,url',
+        )  # fmt: skip
+        if code != 0:
+            continue
+        for run in _parse_runs(out):
+            if run.get('headBranch') == tag and run.get('url'):
+                return run['url']
+    return ACTIONS_URL
+
+
 def _confirm_tag(version: str, commands: Sequence[Command]) -> None:
     head = _run('git', 'log', '-1', '--format=%h %s')
     ladder = '\n'.join(_render_commands(commands, ''))
@@ -481,10 +528,12 @@ def _tag_flow() -> None:
     _confirm_tag(version, commands)
     for cmd in commands:
         _run(*cmd, echo=True)
+    console.print('  [dim]waiting for the workflow run to appear...[/]')
+    run_url = _release_run_url(f'v{version}')
     console.print()
     console.print(
         Panel(
-            f'v{version} is on its way:\n{ACTIONS_URL}',
+            f'v{version} is on its way:\n{run_url}',
             title='🎉 Released',
             border_style='green',
         )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn, TypeAlias
 
+import tomllib
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -99,10 +101,11 @@ def _parse_semver(text: str) -> tuple[int, int, int]:
 
 
 def _current_version() -> str:
-    m = re.search(r'version = "(\d+\.\d+\.\d+)"', PYPROJECT.read_text(encoding='utf-8'))
-    if not m:
+    data = tomllib.loads(PYPROJECT.read_text(encoding='utf-8'))
+    version = data.get('project', {}).get('version')
+    if not isinstance(version, str):
         _error(f'could not find version in {PYPROJECT}')
-    return m.group(1)
+    return version
 
 
 def _bumped(current: str, part: str) -> str:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -211,6 +211,18 @@ def _check_tree_clean() -> None:
         _ok('working tree clean')
 
 
+def _offer_switch_to_main(current: str, refusal: str) -> None:
+    """Move to main with consent; local edits must not travel between branches."""
+    # -uno: untracked files stay put on switch, only tracked edits can travel.
+    if _run('git', 'status', '--porcelain', '-uno'):
+        _error(f'{refusal} - and the tree has local changes, commit or stash them')
+    _warn(f'current branch is {current}, the release continues from main')
+    if not Confirm.ask('  Switch to main?', default=False):
+        _error(refusal)
+    _run('git', 'switch', 'main', echo=True)
+    _ok('switched to main')
+
+
 def _check_branch(branch: str) -> bool:
     """
     Ensure the start point: a fresh main or the existing release branch.
@@ -226,7 +238,9 @@ def _check_branch(branch: str) -> bool:
         _ok(f'already on {branch} - continuing here')
         return False
     if current != 'main':
-        _error(f'start from main (or {branch}), current branch is {current}')
+        _offer_switch_to_main(
+            current, f'start from main (or {branch}), current branch is {current}'
+        )
     _run('git', 'pull', '--ff-only', 'origin', 'main')
     _ok('on main, fast-forwarded to origin/main')
     return True
@@ -422,7 +436,7 @@ def _check_main_ready() -> str:
     """Tagging happens on a fresh main that already carries the merged release."""
     current = _run('git', 'rev-parse', '--abbrev-ref', 'HEAD')
     if current != 'main':
-        _error(f'tagging happens on main - run: git checkout main (now on {current})')
+        _offer_switch_to_main(current, f'tagging happens on main (now on {current})')
     _check_tree_clean()
     _run('git', 'pull', '--ff-only')
     _run('git', 'fetch', '--tags', 'origin')


### PR DESCRIPTION
## Summary

Three quality-of-life fixes for the release wizard. It now offers to switch to `main` instead of refusing when started elsewhere, reads the project version with `tomllib` instead of a regex, and after pushing the tag prints the direct link to the workflow run it has just started.

## Problem

- Starting the wizard from a feature branch (or the release branch during `release:tag`) ended with a hard error and a manual `git checkout main`
- The version was fished out of `pyproject.toml` with a regex - fragile against any formatting or layout change
- After the tag push the wizard linked to the workflow's runs list, not to the run itself - watching the release meant finding it by hand

## Fix

- Both flows ask `Switch to main? [y/N]` and switch themselves; the offer appears only on a clean tree (`-uno`, same policy as the tree check), so tracked edits never travel between branches - declining keeps the old refusal
- `_current_version` parses the file with `tomllib`; writing stays regex-based on purpose - stdlib cannot write TOML preserving formatting
- After `git push origin vX.Y.Z` the wizard polls `gh run list` briefly (the run spawns a few seconds after the push), matches it by `headBranch == vX.Y.Z` and prints the exact run URL; the run page shows the whole three-job pipeline live - on timeout or any gh hiccup it falls back to the old runs-list link
- `docs/development/04-releasing.md` synced: the manual `git checkout main` step is gone

## Verification

- Live wizard runs from a scratch branch: agree - warns, switches, fast-forwards and continues preflight; decline - old refusal, branch untouched; CHANGELOG edits on a foreign branch - refused with an explanation, no prompt
- `tomllib` and the old regex return the same version on the live `pyproject.toml`
- Run resolution finds the historical `v3.4.0` run (the exact URL) in 1 second; a nonexistent tag falls back to the runs list after the poll window
- `task check` green (ruff, format, pyright), 107 unit tests pass; `test:api` is flaky against the live Boosty network today and is unrelated - this PR touches only `scripts/` and docs