### PR TITLE
[downloader] Recognize ondemand video types and skip stream-only videos honestly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Fixed
+
+- New Boosty video url types `ondemand_dash` / `ondemand_hls` no longer trigger the "please report this at GitHub" warning - the client knows them now
+- A video that offers only streaming manifests (hls/dash/live) is skipped with an honest "streams are not supported yet" warning and retried on the next run; a manifest can no longer end up on disk pretending to be a video file
+
 ## 3.4.0
 
 ### Added

--- a/boosty_downloader/src/application/mappers/post_mapper.py
+++ b/boosty_downloader/src/application/mappers/post_mapper.py
@@ -48,9 +48,12 @@ class PostMappingResult:
     # Content this client doesn't know yet, raw. Rendering it for the user
     # is the output layer's job (inline warnings and the run summary).
     unknown_content: set[UnknownContent] = field(default_factory=set[UnknownContent])
+    # Titles of videos that offer only streaming manifests: skipped with
+    # a warning and retried next run in case downloadable urls appear.
+    stream_only_videos: list[str] = field(default_factory=list[str])
 
 
-def map_post_dto_to_domain(  # noqa: C901
+def map_post_dto_to_domain(  # noqa: C901, PLR0912 - one match-dispatcher over every chunk type
     post_dto: PostDTO, preferred_video_quality: BoostyOkVideoType
 ) -> PostMappingResult:
     """Convert a Boosty API PostDTO object to a domain Post object, mapping all data chunks to their domain representations."""
@@ -65,6 +68,7 @@ def map_post_dto_to_domain(  # noqa: C901
     )
 
     incomplete_content_types: set[DownloadContentTypeFilter] = set()
+    stream_only_videos: list[str] = []
     # One type-driven walk over the whole parsed post: any tolerant field
     # or unknown chunk is reported automatically, wherever it sits.
     unknown_content = collect_unknown_content(post_dto)
@@ -98,6 +102,12 @@ def map_post_dto_to_domain(  # noqa: C901
                 )
                 if video_chunk is not None:
                     post.post_data_chunks.append(video_chunk)
+                elif any(u.url for u in data_chunk.player_urls):
+                    # Streams may gain downloadable urls later: retry next run.
+                    incomplete_content_types.add(
+                        DownloadContentTypeFilter.boosty_videos
+                    )
+                    stream_only_videos.append(data_chunk.title)
             case BoostyPostDataExternalVideoDTO():
                 post.post_data_chunks.append(
                     mappers.to_external_video_content(data_chunk)
@@ -115,4 +125,5 @@ def map_post_dto_to_domain(  # noqa: C901
         post=post,
         incomplete_content_types=incomplete_content_types,
         unknown_content=unknown_content,
+        stream_only_videos=stream_only_videos,
     )

--- a/boosty_downloader/src/application/ok_video_ranking.py
+++ b/boosty_downloader/src/application/ok_video_ranking.py
@@ -70,6 +70,8 @@ def get_quality_ranking() -> RankingDict[BoostyOkVideoType]:
     quality_ranking[BoostyOkVideoType.dash] = 3
     quality_ranking[BoostyOkVideoType.dash_uni] = 2
     quality_ranking[BoostyOkVideoType.live_cmaf] = 1
+    quality_ranking[BoostyOkVideoType.ondemand_hls] = 0
+    quality_ranking[BoostyOkVideoType.ondemand_dash] = -1
 
     return quality_ranking
 

--- a/boosty_downloader/src/application/ok_video_ranking.py
+++ b/boosty_downloader/src/application/ok_video_ranking.py
@@ -50,6 +50,23 @@ class RankingDict(Generic[KT]):
         return None
 
 
+# The only formats download_file can save: plain progressive mp4 files.
+# Everything else (hls/dash/live/ondemand) is a streaming manifest and
+# needs a stream assembler the client does not have.
+DOWNLOADABLE_TYPES = frozenset(
+    {
+        BoostyOkVideoType.ultra_hd,
+        BoostyOkVideoType.quad_hd,
+        BoostyOkVideoType.full_hd,
+        BoostyOkVideoType.high,
+        BoostyOkVideoType.medium,
+        BoostyOkVideoType.low,
+        BoostyOkVideoType.tiny,
+        BoostyOkVideoType.lowest,
+    }
+)
+
+
 def get_quality_ranking() -> RankingDict[BoostyOkVideoType]:
     """Get the ranking dict for video quality"""
     quality_ranking = RankingDict[BoostyOkVideoType]()
@@ -89,6 +106,8 @@ def get_best_video(
     while highest_rank_video_type := quality_ranking.pop_max():
         highest_rank_video_type = highest_rank_video_type[0]
 
+        if highest_rank_video_type not in DOWNLOADABLE_TYPES:
+            continue
         video_url = video_urls_map.get(highest_rank_video_type)
         if video_url and video_url.url:
             return video_url, highest_rank_video_type

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -174,6 +174,11 @@ class DownloadSinglePostUseCase:
             self.context.progress_reporter.warn(
                 f'Post has unfinished uploads (will retry next run): {self.destination.name}'
             )
+        for video_title in mapping_result.stream_only_videos:
+            self.context.progress_reporter.warn(
+                'Skip video (streams are not supported yet): '
+                + (video_title.strip() or 'video')
+            )
 
         missing_parts: list[DownloadContentTypeFilter] = (
             self.context.post_cache.get_post_missing_parts(

--- a/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/models/post/post_data_types/post_data_ok_video.py
@@ -27,6 +27,8 @@ class BoostyOkVideoType(Enum):
     dash = 'dash'
     dash_uni = 'dash_uni'
     live_cmaf = 'live_cmaf'
+    ondemand_hls = 'ondemand_hls'
+    ondemand_dash = 'ondemand_dash'
 
     ultra_hd = 'ultra_hd'
     quad_hd = 'quad_hd'

--- a/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/utils/validation_errors.py
@@ -22,7 +22,7 @@ GITHUB_ISSUES_URL = 'https://github.com/Glitchy-Sheep/boosty-downloader/issues'
 
 def format_validation_errors(errors: Sequence[ErrorDetails]) -> list[str]:
     """
-    Turn pydantic error details into lines like ``data[8].playerUrls[4].type: unknown value 'ondemand_dash'``.
+    Turn pydantic error details into lines like ``data[8].playerUrls[4].type: unknown value 'imaginary_dash'``.
 
     The path style matches collect_unknown_content, so users see the same
     addressing everywhere. Enum mismatches show the offending word instead

--- a/test/unit/boosty_api/ok_video_types_test.py
+++ b/test/unit/boosty_api/ok_video_types_test.py
@@ -13,13 +13,21 @@ from boosty_downloader.src.infrastructure.boosty_api.models.unknown_value import
 )
 
 
-@pytest.mark.parametrize('new_type', ['ondemand_dash', 'ondemand_hls'])
+@pytest.mark.parametrize('new_type', ['imaginary_dash', 'imaginary_hls'])
 def test_unknown_url_type_keeps_raw_word(new_type: str):
     url = BoostyOkVideoUrl.model_validate(
         {'url': 'https://vd.example/1', 'type': new_type}
     )
 
     assert url.type == BoostyUnknownValue(raw=new_type)
+
+
+@pytest.mark.parametrize('ondemand_type', ['ondemand_dash', 'ondemand_hls'])
+def test_ondemand_types_parse_into_the_enum(ondemand_type: str):
+    """The Aug 2026 additions must not fire the report-to-github warning."""
+    url = BoostyOkVideoUrl.model_validate({'url': '', 'type': ondemand_type})
+
+    assert url.type is BoostyOkVideoType(ondemand_type)
 
 
 def test_known_url_type_still_parses_exactly():

--- a/test/unit/boosty_api/validation_errors_test.py
+++ b/test/unit/boosty_api/validation_errors_test.py
@@ -42,10 +42,10 @@ def _real_errors(payload: dict) -> list:
 
 def test_enum_error_shows_the_offending_word():
     lines = format_validation_errors(
-        _real_errors({'data': [{'type': 'ondemand_dash'}], 'title': 't'})
+        _real_errors({'data': [{'type': 'imaginary_dash'}], 'title': 't'})
     )
 
-    assert lines == ["data[0].type: unknown value 'ondemand_dash'"]
+    assert lines == ["data[0].type: unknown value 'imaginary_dash'"]
 
 
 def test_non_enum_error_keeps_pydantic_message():

--- a/test/unit/download_manager/ok_video_ranking_test.py
+++ b/test/unit/download_manager/ok_video_ranking_test.py
@@ -131,3 +131,30 @@ def test_only_unknown_types_gives_none():
     ]
 
     assert get_best_video(video_urls) is None
+
+
+def test_stream_manifest_is_never_selected():
+    """A manifest url handed to download_file lands on disk as a text file."""
+    video_urls = [
+        BoostyOkVideoUrl(
+            url='https://vd.example/video.m3u8', type=BoostyOkVideoType.hls
+        ),
+        BoostyOkVideoUrl(url='https://vd.example/mpd', type=BoostyOkVideoType.dash),
+    ]
+
+    assert get_best_video(video_urls) is None
+
+
+def test_progressive_beats_a_stream_regardless_of_rank():
+    """The lowest mp4 is a real video; the best manifest is not downloadable."""
+    video_urls = [
+        BoostyOkVideoUrl(
+            url='https://vd.example/video.m3u8', type=BoostyOkVideoType.hls
+        ),
+        BoostyOkVideoUrl(url='https://vd.example/tiny', type=BoostyOkVideoType.tiny),
+    ]
+
+    best_video = get_best_video(video_urls)
+
+    assert best_video is not None
+    assert best_video[1] == BoostyOkVideoType.tiny

--- a/test/unit/download_manager/ok_video_ranking_test.py
+++ b/test/unit/download_manager/ok_video_ranking_test.py
@@ -109,7 +109,7 @@ def test_known_quality_beats_unknown_type():
     video_urls = [
         BoostyOkVideoUrl(
             url='https://vd.example/unknown',
-            type=BoostyUnknownValue(raw='ondemand_dash'),
+            type=BoostyUnknownValue(raw='imaginary_dash'),
         ),
         BoostyOkVideoUrl(
             url='https://vd.example/medium', type=BoostyOkVideoType.medium
@@ -126,7 +126,7 @@ def test_only_unknown_types_gives_none():
     video_urls = [
         BoostyOkVideoUrl(
             url='https://vd.example/unknown',
-            type=BoostyUnknownValue(raw='ondemand_dash'),
+            type=BoostyUnknownValue(raw='imaginary_dash'),
         ),
     ]
 

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -186,7 +186,7 @@ def test_unknown_video_url_type_is_reported_not_fatal():
         complete=True,
         player_urls=[
             BoostyOkVideoUrl(
-                type=BoostyUnknownValue(raw='ondemand_dash'), url='https://e/1'
+                type=BoostyUnknownValue(raw='imaginary_dash'), url='https://e/1'
             ),
             BoostyOkVideoUrl(type=BoostyOkVideoType.medium, url='https://e/2'),
         ],
@@ -198,7 +198,7 @@ def test_unknown_video_url_type_is_reported_not_fatal():
 
     assert len(result.post.post_data_chunks) == 1
     assert result.unknown_content == {
-        UnknownContent(path='data[0].playerUrls[0].type', raw='ondemand_dash')
+        UnknownContent(path='data[0].playerUrls[0].type', raw='imaginary_dash')
     }
 
 

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -202,6 +202,52 @@ def test_unknown_video_url_type_is_reported_not_fatal():
     }
 
 
+def _video_with_urls(urls: list[BoostyOkVideoUrl]) -> BoostyPostDataOkVideoDTO:
+    return BoostyPostDataOkVideoDTO(
+        type='ok_video',
+        id='vid-1',
+        title='Стрим-запись',
+        failover_host='https://example.com',
+        duration=timedelta(seconds=120),
+        upload_status='ok',
+        complete=True,
+        player_urls=urls,
+    )
+
+
+def test_stream_only_video_is_skipped_with_a_warning_and_a_retry():
+    """A silent drop hides the video from the user forever."""
+    video = _video_with_urls(
+        [BoostyOkVideoUrl(type=BoostyOkVideoType.hls, url='https://e/v.m3u8')]
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([video]), preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert result.post.post_data_chunks == []
+    assert result.stream_only_videos == ['Стрим-запись']
+    assert DownloadContentTypeFilter.boosty_videos in result.incomplete_content_types
+
+
+def test_video_with_all_empty_urls_stays_silently_dropped():
+    """No content at all is not a stream: the warning must not lie."""
+    video = _video_with_urls(
+        [
+            BoostyOkVideoUrl(type=BoostyOkVideoType.hls, url=''),
+            BoostyOkVideoUrl(type=BoostyOkVideoType.medium, url=''),
+        ]
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([video]), preferred_video_quality=BoostyOkVideoType.medium
+    )
+
+    assert result.post.post_data_chunks == []
+    assert result.stream_only_videos == []
+    assert result.incomplete_content_types == set()
+
+
 def test_list_with_unknown_style_keeps_its_items():
     list_chunk = BoostyPostDataListDTO.model_validate(
         {


### PR DESCRIPTION
## Summary

Boosty added two new video url types: `ondemand_dash` and `ondemand_hls`. Every run over a post with them nagged "please report this at GitHub". The client now knows these types. Selection also got a safety rule: only progressive mp4 formats are downloadable, and a video with nothing but streaming manifests is skipped with an honest warning.

## Problem

- The unknown-content reporter fired on `ondemand_*` at every check and download. The videos themselves downloaded fine - the warning was pure noise.
- A live probe showed these types come with empty urls even with full access: Boosty rolled out the words, not the content.
- Selection had a trap: with no mp4 available it silently fell back to `hls`/`dash` manifest urls, and `download_file` saved the manifest text to disk as a fake video.

## Fix

- `ondemand_hls` / `ondemand_dash` join the enum at the bottom of the ranking. The report-to-github warning no longer fires for them.
- `get_best_video` picks from an explicit allowlist of 8 progressive mp4 types. A manifest url can never reach the file downloader. New types stay non-downloadable until recognized.
- A video with only stream urls warns `Skip video (streams are not supported yet): <title>` and retries next run. If Boosty starts serving downloadable urls, it downloads by itself.
- A video with no urls at all keeps the old silent drop - a stream warning there would lie.
- Tests that need an unknown url type use a fictional `imaginary_*` word.

## Before / After

**Before:** every `check` / `download` over such posts prints unknown-content warnings and asks to report them.

**After:** the same commands are quiet, videos download exactly as before, and a stream-only video says honestly that streams are not supported yet.

## Verification

- Live `check` over a real blog with these types: the ondemand warnings are gone.
- Live download of a video post: a genuine `ISO Media MP4` lands on disk - no manifests, no warnings.
- A live authorized API probe confirmed the `ondemand_*` urls are empty for every probed video, so nothing downloadable is skipped.
- 6 new unit tests: the types parse, manifests are never selected, the worst mp4 beats the best manifest, stream-only warns and retries, url-less stays silent.
- Full `task ci` green: checks, 113 unit tests, 6 live integration tests, build.
