### PR TITLE
[downloader] Re-fetch posts with expired signed links and fetch single posts directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ### Fixed
 
+- Long runs no longer die on expired download links: when the CDN rejects a link that lived past its ~24-hour signature, the post is re-fetched from the API once and the download retries with fresh links - no manual rerun needed
 - New Boosty video url types `ondemand_dash` / `ondemand_hls` no longer trigger the "please report this at GitHub" warning - the client knows them now
 - A video that offers only streaming manifests (hls/dash/live) is skipped with an honest "streams are not supported yet" warning and retried on the next run; a manifest can no longer end up on disk pretending to be a video file
+
+### Changed
+
+- `--post-url` finds the post with one direct API request instead of walking the whole blog page by page - instant start and download links that are always fresh; a paywalled post without access now says so instead of saving an empty preview
 
 ## 3.4.0
 

--- a/boosty_downloader/src/application/post_retry.py
+++ b/boosty_downloader/src/application/post_retry.py
@@ -1,0 +1,194 @@
+"""Per-post retry policy: attempts, backoff and one expired-link refresh."""
+
+import asyncio
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+
+from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.exceptions.application_errors import (
+    ApplicationCancelledError,
+    ApplicationFailedDownloadError,
+)
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+    compose_post_directory_name,
+)
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPIClient,
+    BoostyAPIError,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+from boosty_downloader.src.infrastructure.file_downloader import is_expired_link_error
+from boosty_downloader.src.infrastructure.path_sanitizer import (
+    PATH_TOO_LONG_HINT,
+    is_path_too_long_error,
+)
+
+MAX_DOWNLOAD_ATTEMPTS = 5
+
+
+class PostOutcome(Enum):
+    """Outcome of one post within the full-download run."""
+
+    downloaded = auto()
+    failed = auto()
+
+
+@dataclass
+class _PostAttempt:
+    """Everything one download try needs; rebuilt when links are refreshed."""
+
+    post_dto: PostDTO
+    use_case: DownloadSinglePostUseCase
+    folder_name: str
+    # A refresh is spent even when it fails: the second 400 on fresh
+    # links means the problem is not expiry.
+    refreshed: bool = False
+
+
+class PostDownloadRetrier:
+    """
+    Download one post, absorbing failures that retrying can heal.
+
+    Owns the attempt budget, the backoff between attempts and the single
+    re-fetch of a post whose signed links expired mid-run.
+    """
+
+    def __init__(
+        self,
+        author_name: str,
+        boosty_api: BoostyAPIClient,
+        destination: Path,
+        download_context: DownloadContext,
+    ) -> None:
+        self.author_name = author_name
+        self.boosty_api = boosty_api
+        self.destination = destination
+        self.context = download_context
+
+    async def download(self, post_dto: PostDTO, failed_posts: list[str]) -> PostOutcome:
+        """Run the retry policy; every exit path is an explicit outcome."""
+        delay = 1.0
+        attempt_state = self._build_attempt(post_dto)
+        for attempt in range(1, MAX_DOWNLOAD_ATTEMPTS + 1):
+            try:
+                await attempt_state.use_case.execute()
+            except ApplicationCancelledError:  # noqa: PERF203 - per-post isolation is the point here
+                raise
+            except ApplicationFailedDownloadError as e:
+                fresh_attempt = await self._refresh_expired_links(attempt_state, e)
+                if fresh_attempt is not None:
+                    attempt_state = fresh_attempt
+                    continue
+                if attempt == MAX_DOWNLOAD_ATTEMPTS:
+                    return self._skip_after_retries(
+                        attempt_state.folder_name, failed_posts, e, attempts=attempt
+                    )
+                delay = await self._wait_before_retry(
+                    attempt_state.folder_name, e, attempt=attempt, delay=delay
+                )
+            # Containment: an unexpected error (e.g. OSError from a too
+            # long post title) skips this post, never the whole run.
+            # Must stay below the cancellation re-raise, or Ctrl+C
+            # would be swallowed here.
+            except Exception as e:  # noqa: BLE001
+                return await self._skip_unexpected(
+                    attempt_state.folder_name,
+                    attempt_state.post_dto.id,
+                    failed_posts,
+                    e,
+                )
+            else:
+                return PostOutcome.downloaded
+        return PostOutcome.failed
+
+    def _build_attempt(self, post_dto: PostDTO) -> _PostAttempt:
+        """Compose the post folder name and the use case that downloads into it."""
+        folder_name = compose_post_directory_name(
+            post_dto.title, post_dto.created_at, post_dto.id
+        )
+        use_case = DownloadSinglePostUseCase(
+            destination=self.destination / folder_name,
+            post_dto=post_dto,
+            download_context=self.context,
+        )
+        return _PostAttempt(
+            post_dto=post_dto, use_case=use_case, folder_name=folder_name
+        )
+
+    async def _refresh_expired_links(
+        self, attempt_state: _PostAttempt, error: ApplicationFailedDownloadError
+    ) -> _PostAttempt | None:
+        """Rebuild the attempt with fresh signed urls; None means retry as usual."""
+        if attempt_state.refreshed or not is_expired_link_error(error):
+            return None
+        attempt_state.refreshed = True
+        self.context.progress_reporter.warn(
+            'Signed links look expired, refreshing the post: '
+            + attempt_state.folder_name
+        )
+        try:
+            fresh_dto = await self.boosty_api.get_single_post(
+                self.author_name, attempt_state.post_dto.id
+            )
+        except BoostyAPIError:
+            # The normal retry/skip path handles the original error.
+            return None
+        fresh_attempt = self._build_attempt(fresh_dto)
+        fresh_attempt.refreshed = True
+        return fresh_attempt
+
+    def _skip_after_retries(
+        self,
+        folder_name: str,
+        failed_posts: list[str],
+        error: ApplicationFailedDownloadError,
+        *,
+        attempts: int,
+    ) -> PostOutcome:
+        """Give up on a post whose known failure survived all retries."""
+        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
+        failed_posts.append(f'{folder_name} ({error.message}){hint}')
+        self.context.progress_reporter.error(
+            f'Skip post after {attempts} failed attempts: '
+            f'{folder_name} ({error.message}){hint}'
+        )
+        return PostOutcome.failed
+
+    async def _skip_unexpected(
+        self,
+        folder_name: str,
+        post_id: str,
+        failed_posts: list[str],
+        error: Exception,
+    ) -> PostOutcome:
+        """Give up on a post immediately: unexpected errors do not heal by retrying."""
+        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
+        failed_posts.append(f'{folder_name} ({error}){hint}')
+        self.context.progress_reporter.error(
+            f'Skip post after unexpected error: {folder_name} ({error}){hint}'
+        )
+        await self.context.failed_logger.add_error(
+            post_id,
+            f'Unexpected error: {error}{hint}',
+        )
+        return PostOutcome.failed
+
+    async def _wait_before_retry(
+        self,
+        folder_name: str,
+        error: ApplicationFailedDownloadError,
+        *,
+        attempt: int,
+        delay: float,
+    ) -> float:
+        """Report the failed attempt, back off, and return the next delay."""
+        self.context.progress_reporter.warn(
+            f'Attempt {attempt} failed for post: {folder_name} ({error.message}), RESOURCE: ({error.resource})'
+        )
+        self.context.progress_reporter.warn(
+            f'Retrying in {delay:.1f}s... ({error.message})'
+        )
+        await asyncio.sleep(delay)
+        return min(delay * 1.5, 10.0)

--- a/boosty_downloader/src/application/use_cases/download_all_posts.py
+++ b/boosty_downloader/src/application/use_cases/download_all_posts.py
@@ -1,22 +1,20 @@
 """Implements the use case for downloading all posts from a Boosty author, applying filters and caching as needed."""
 
-import asyncio
-from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.exceptions.application_errors import (
-    ApplicationCancelledError,
-    ApplicationFailedDownloadError,
     ApplicationTooManyFailuresError,
 )
 from boosty_downloader.src.application.failure_streak import FailureStreakBreaker
-from boosty_downloader.src.application.use_cases.download_single_post import (
-    DownloadSinglePostUseCase,
-    compose_post_directory_name,
+from boosty_downloader.src.application.post_retry import (
+    PostDownloadRetrier,
+    PostOutcome,
 )
-from boosty_downloader.src.infrastructure.boosty_api.core.client import BoostyAPIClient
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPIClient,
+)
 from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
     UnknownContent,
     collect_unknown_content,
@@ -24,10 +22,6 @@ from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content impo
 from boosty_downloader.src.infrastructure.boosty_api.utils.validation_errors import (
     format_run_summary,
     format_skipped_post,
-)
-from boosty_downloader.src.infrastructure.path_sanitizer import (
-    PATH_TOO_LONG_HINT,
-    is_path_too_long_error,
 )
 
 # Failures of posts in a row, without a single success in between.
@@ -40,13 +34,6 @@ if TYPE_CHECKING:
         PostsResponse,
         SkippedPost,
     )
-
-
-class _PostOutcome(Enum):
-    """Outcome of one post within the full-download run."""
-
-    downloaded = auto()
-    failed = auto()
 
 
 class DownloadAllPostUseCase:
@@ -74,6 +61,12 @@ class DownloadAllPostUseCase:
         self.destination = destination
         self.context = download_context
         self.skip_all_failures = skip_all_failures
+        self._post_retrier = PostDownloadRetrier(
+            author_name=author_name,
+            boosty_api=boosty_api,
+            destination=destination,
+            download_context=download_context,
+        )
 
     def _note_page_anomalies(
         self,
@@ -87,96 +80,6 @@ class DownloadAllPostUseCase:
             unknown_content |= collect_unknown_content(post_dto)
         for skipped in page.skipped_posts:
             self.context.progress_reporter.warn(format_skipped_post(skipped))
-
-    async def _download_one_post(
-        self,
-        single_post_use_case: DownloadSinglePostUseCase,
-        *,
-        full_post_title: str,
-        post_id: str,
-        failed_posts: list[str],
-    ) -> _PostOutcome:
-        """Run the per-post retry policy; every exit path is an explicit outcome."""
-        max_attempts = 5
-        delay = 1.0
-        for attempt in range(1, max_attempts + 1):
-            try:
-                await single_post_use_case.execute()
-            except ApplicationCancelledError:  # noqa: PERF203 - per-post isolation is the point here
-                raise
-            except ApplicationFailedDownloadError as e:
-                if attempt == max_attempts:
-                    return self._skip_after_retries(
-                        full_post_title, failed_posts, e, attempts=attempt
-                    )
-                delay = await self._wait_before_retry(
-                    full_post_title, e, attempt=attempt, delay=delay
-                )
-            # Containment: an unexpected error (e.g. OSError from a too
-            # long post title) skips this post, never the whole run.
-            # Must stay below the cancellation re-raise, or Ctrl+C
-            # would be swallowed here.
-            except Exception as e:  # noqa: BLE001
-                return await self._skip_unexpected(
-                    full_post_title, post_id, failed_posts, e
-                )
-            else:
-                return _PostOutcome.downloaded
-        return _PostOutcome.failed
-
-    def _skip_after_retries(
-        self,
-        full_post_title: str,
-        failed_posts: list[str],
-        error: ApplicationFailedDownloadError,
-        *,
-        attempts: int,
-    ) -> _PostOutcome:
-        """Give up on a post whose known failure survived all retries."""
-        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
-        failed_posts.append(f'{full_post_title} ({error.message}){hint}')
-        self.context.progress_reporter.error(
-            f'Skip post after {attempts} failed attempts: '
-            f'{full_post_title} ({error.message}){hint}'
-        )
-        return _PostOutcome.failed
-
-    async def _skip_unexpected(
-        self,
-        full_post_title: str,
-        post_id: str,
-        failed_posts: list[str],
-        error: Exception,
-    ) -> _PostOutcome:
-        """Give up on a post immediately: unexpected errors do not heal by retrying."""
-        hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(error) else ''
-        failed_posts.append(f'{full_post_title} ({error}){hint}')
-        self.context.progress_reporter.error(
-            f'Skip post after unexpected error: {full_post_title} ({error}){hint}'
-        )
-        await self.context.failed_logger.add_error(
-            post_id,
-            f'Unexpected error: {error}{hint}',
-        )
-        return _PostOutcome.failed
-
-    async def _wait_before_retry(
-        self,
-        full_post_title: str,
-        error: ApplicationFailedDownloadError,
-        *,
-        attempt: int,
-        delay: float,
-    ) -> float:
-        """Report the failed attempt, back off, and return the next delay."""
-        self.context.progress_reporter.warn(
-            f'Attempt {attempt} failed for post: {full_post_title} ({error.message}), RESOURCE: ({error.resource})'
-        )
-        self.context.progress_reporter.warn(
-            f'Retrying in {delay:.1f}s... ({error.message})'
-        )
-        await asyncio.sleep(delay)
-        return min(delay * 1.5, 10.0)
 
     async def execute(self) -> None:
         posts_iterator = self.boosty_api.iterate_over_posts(
@@ -213,29 +116,14 @@ class DownloadAllPostUseCase:
                     )
                     continue
 
-                full_post_title = compose_post_directory_name(
-                    post_dto.title, post_dto.created_at, post_dto.id
-                )
-
-                single_post_use_case = DownloadSinglePostUseCase(
-                    destination=self.destination / full_post_title,
-                    post_dto=post_dto,
-                    download_context=self.context,
-                )
-
                 self.context.progress_reporter.update_task(
                     page_task_id,
                     advance=1,
                     description=f'Processing page [bold]{current_page}[/bold]',
                 )
 
-                outcome = await self._download_one_post(
-                    single_post_use_case,
-                    full_post_title=full_post_title,
-                    post_id=post_dto.id,
-                    failed_posts=failed_posts,
-                )
-                if outcome is _PostOutcome.downloaded:
+                outcome = await self._post_retrier.download(post_dto, failed_posts)
+                if outcome is PostOutcome.downloaded:
                     processed_ok += 1
                     breaker.record_success()
                 elif breaker.record_failure():

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -16,6 +16,13 @@ from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
     compose_post_directory_name,
 )
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPINoPostError,
+    BoostyAPIValidationError,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
+    SkippedPost,
+)
 from boosty_downloader.src.infrastructure.boosty_api.models.unknown_content import (
     collect_unknown_content,
 )
@@ -33,9 +40,6 @@ if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.post import (
         PostDTO,
     )
-    from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
-        PostsResponse,
-    )
 
 
 class _PostDownloadOutcome(Enum):
@@ -50,10 +54,7 @@ class DownloadPostByUrlUseCase:
     """
     Handles downloading a specific Boosty post given its URL.
 
-    Right now it just iterates over the post and downloads it if UUID matches.
-    Because I can't find a way to get post by URL directly at this moment.
-
-    If you know how to do it, please open an issue on GitHub or PR with this functionality.
+    The post is requested directly by id - one API call, fresh signed urls.
     """
 
     def __init__(
@@ -93,22 +94,6 @@ class DownloadPostByUrlUseCase:
         else:
             return author, post_uuid
 
-    def _report_if_target_skipped(self, page: 'PostsResponse', post_uuid: str) -> bool:
-        """
-        Tell the user when the searched post exists but this client can't parse it.
-
-        A misleading "not found" would hide the real problem.
-        """
-        for skipped in page.skipped_posts:
-            if skipped.post_id == post_uuid:
-                self.context.progress_reporter.error(format_skipped_post(skipped))
-                self.context.progress_reporter.error(
-                    f'Please report this at {GITHUB_ISSUES_URL} '
-                    'so the client can be updated.'
-                )
-                return True
-        return False
-
     async def execute(self) -> None:
         author_name, post_uuid = self.extract_author_and_uuid_from_url()
         if not author_name or not post_uuid:
@@ -117,29 +102,37 @@ class DownloadPostByUrlUseCase:
             )
             return
 
-        current_page = 0
-
-        async for page in self.boosty_api.iterate_over_posts(
-            author_name=author_name, posts_per_page=100
-        ):
-            current_page += 1
-            self.context.progress_reporter.info(
-                f'[Page({current_page})] Searching for the post with UUID: {post_uuid}... '
-            )
-            if self._report_if_target_skipped(page, post_uuid):
-                return
-
-            for post in page.posts:
-                if post.id == post_uuid:
-                    outcome = await self._download_post(post)
-                    if outcome is _PostDownloadOutcome.downloaded:
-                        return
-                    # Note: cancel does not stop the search - it moves on
-                    # like a failed download.
-
-        self.context.progress_reporter.error(
-            'Failed to find and download the specified post.'
+        self.context.progress_reporter.info(
+            f'Requesting the post with UUID: {post_uuid}...'
         )
+        try:
+            post = await self.boosty_api.get_single_post(author_name, post_uuid)
+        except BoostyAPINoPostError:
+            self.context.progress_reporter.error(
+                'Failed to find and download the specified post.'
+            )
+            return
+        except BoostyAPIValidationError as e:
+            # The searched post exists but this client can't parse it -
+            # a misleading "not found" would hide the real problem.
+            self.context.progress_reporter.error(
+                format_skipped_post(
+                    SkippedPost(post_id=post_uuid, title='<unparsed>', errors=e.errors)
+                )
+            )
+            self.context.progress_reporter.error(
+                f'Please report this at {GITHUB_ISSUES_URL} '
+                'so the client can be updated.'
+            )
+            return
+
+        if not post.has_access:
+            self.context.progress_reporter.error(
+                f'Skip post (no access to content): {post.title}'
+            )
+            return
+
+        await self._download_post(post)
 
     async def _download_post(self, post: 'PostDTO') -> _PostDownloadOutcome:
         """Download the found post and name how it went."""

--- a/boosty_downloader/src/infrastructure/boosty_api/core/client.py
+++ b/boosty_downloader/src/infrastructure/boosty_api/core/client.py
@@ -70,6 +70,13 @@ class BoostyAPIUnknownError(BoostyAPIError):
         self.details = details
 
 
+class BoostyAPINoPostError(BoostyAPIError):
+    """Raised when the requested post does not exist in the author's blog."""
+
+    def __init__(self, author_name: str, post_id: str) -> None:
+        super().__init__(f'Post {post_id} not found in blog {author_name}')
+
+
 class BoostyAPIValidationError(BoostyAPIError):
     """
     Raised when validation error occurs, e.g. when response data is invalid.
@@ -216,6 +223,40 @@ class BoostyAPIClient:
             extra=extra,
             skipped_posts=skipped_posts,
         )
+
+    async def get_single_post(self, author_name: str, post_id: str) -> PostDTO:
+        """
+        Request one post directly: fresh signed urls in a single call.
+
+        Used to find a post by url without walking the listing and to
+        refresh expired signed links mid-run.
+        """
+        endpoint = f'blog/{author_name}/post/{post_id}'
+        post_raw = await self._throttled_get(endpoint)
+
+        if post_raw.status == HTTPStatus.NOT_FOUND:
+            raise BoostyAPINoPostError(author_name, post_id)
+        if post_raw.status == HTTPStatus.UNAUTHORIZED:
+            raise BoostyAPIUnauthorizedError
+        if post_raw.status != HTTPStatus.OK:
+            raise BoostyAPIUnknownError(
+                post_raw.status, f'Unexpected status code: {post_raw.status}'
+            )
+
+        # Status is OK here, so a non-JSON body means a broken response
+        try:
+            post_data = await post_raw.json()
+        except (ContentTypeError, json.JSONDecodeError) as e:
+            raise BoostyAPIUnknownError(
+                post_raw.status, 'Non-JSON response from the API'
+            ) from e
+
+        # A single post has no page to survive on: a post this client
+        # can't parse is an explicit error with the details to report.
+        try:
+            return PostDTO.model_validate(post_data)
+        except ValidationError as e:
+            raise BoostyAPIValidationError(errors=e.errors()) from e
 
     async def iterate_over_posts(
         self,

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -129,6 +129,26 @@ def _author_filename(name: str) -> str:
     return sanitize_filename(pure.stem, suffix=sanitize_filename(ext) if ext else '')
 
 
+# What a CDN answers on a dead signature; 403 can also mean genuinely
+# no access - one refresh attempt safely tells the two apart.
+_EXPIRED_LINK_STATUSES = frozenset(
+    {http.HTTPStatus.BAD_REQUEST, http.HTTPStatus.FORBIDDEN}
+)
+
+
+def is_expired_link_error(error: BaseException | None) -> bool:
+    """Check the error or its causes for a CDN answer typical of expired urls."""
+    current = error
+    while current is not None:
+        if (
+            isinstance(current, DownloadUnexpectedStatusError)
+            and current.status_code in _EXPIRED_LINK_STATUSES
+        ):
+            return True
+        current = current.__cause__
+    return False
+
+
 def _extension_to_append(content_type: str | None) -> str | None:
     """
     Pick an extension for a name that has none by construction.

--- a/test/unit/boosty_api/client_test.py
+++ b/test/unit/boosty_api/client_test.py
@@ -12,6 +12,7 @@ from aiohttp import ContentTypeError
 from boosty_downloader.src.infrastructure.boosty_api.core.client import (
     BoostyAPIClient,
     BoostyAPIInvalidUsernameError,
+    BoostyAPINoPostError,
     BoostyAPINoUsernameError,
     BoostyAPIUnauthorizedError,
     BoostyAPIUnknownError,
@@ -190,3 +191,43 @@ async def test_broken_pagination_still_fails_the_page():
 
     with pytest.raises(BoostyAPIValidationError):
         await client.get_author_posts('any_author', limit=1)
+
+
+@pytest.mark.asyncio
+async def test_single_post_parses_into_dto():
+    client = _make_client(_FakeResponse(status=200, json_data=VALID_POST))
+
+    post = await client.get_single_post('any_author', 'p1')
+
+    assert post.id == 'p1'
+    assert post.title == 'ok post'
+
+
+@pytest.mark.asyncio
+async def test_single_post_404_names_the_missing_post():
+    """A silent None would make 'not found' look like a network problem."""
+    client = _make_client(_FakeResponse(status=404, json_data={}))
+
+    with pytest.raises(BoostyAPINoPostError, match=r'p1.*any_author'):
+        await client.get_single_post('any_author', 'p1')
+
+
+@pytest.mark.asyncio
+async def test_single_post_validation_error_carries_details():
+    """One post has no page to survive on: broken parsing must say what broke."""
+    client = _make_client(
+        _FakeResponse(status=200, json_data={'id': 'b1', 'title': 'broken'})
+    )
+
+    with pytest.raises(BoostyAPIValidationError) as exc_info:
+        await client.get_single_post('any_author', 'b1')
+
+    assert exc_info.value.errors
+
+
+@pytest.mark.asyncio
+async def test_single_post_401_raises_unauthorized():
+    client = _make_client(_FakeResponse(status=401, json_data={}))
+
+    with pytest.raises(BoostyAPIUnauthorizedError):
+        await client.get_single_post('any_author', 'p1')

--- a/test/unit/use_cases/download_all_posts_test.py
+++ b/test/unit/use_cases/download_all_posts_test.py
@@ -10,9 +10,11 @@ from typing import TYPE_CHECKING, cast
 
 import pytest
 
+from boosty_downloader.src.application import post_retry as post_retry_module
 from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.exceptions.application_errors import (
     ApplicationCancelledError,
+    ApplicationFailedDownloadError,
     ApplicationTooManyFailuresError,
 )
 from boosty_downloader.src.application.filtering import BoostyOkVideoType
@@ -22,10 +24,16 @@ from boosty_downloader.src.application.use_cases.download_all_posts import (
 from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
 )
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPIUnknownError,
+)
 from boosty_downloader.src.infrastructure.boosty_api.models.post.extra import Extra
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 from boosty_downloader.src.infrastructure.boosty_api.models.post.posts_request import (
     PostsResponse,
+)
+from boosty_downloader.src.infrastructure.file_downloader import (
+    DownloadUnexpectedStatusError,
 )
 
 if TYPE_CHECKING:
@@ -89,16 +97,28 @@ class _FakeFailedLogger:
 
 
 class _FakeApi:
-    """One page of posts, then stop."""
+    """One page of posts, then stop; single-post re-fetch is scriptable."""
 
-    def __init__(self, page: PostsResponse) -> None:
+    def __init__(
+        self, page: PostsResponse | None = None, refetch_error: Exception | None = None
+    ) -> None:
         self._page = page
+        self._refetch_error = refetch_error
+        self.refetched: list[str] = []
 
     async def iterate_over_posts(
         self, *args: object, **kwargs: object
     ) -> AsyncGenerator[PostsResponse, None]:
         del args, kwargs
+        assert self._page is not None
         yield self._page
+
+    async def get_single_post(self, author_name: str, post_id: str) -> PostDTO:
+        del author_name
+        self.refetched.append(post_id)
+        if self._refetch_error is not None:
+            raise self._refetch_error
+        return _post(post_id)
 
 
 def _post(post_id: str) -> PostDTO:
@@ -119,11 +139,14 @@ def _use_case(
     failed_logger: _FakeFailedLogger,
     *,
     skip_all_failures: bool = False,
+    api: _FakeApi | None = None,
 ) -> DownloadAllPostUseCase:
     page = PostsResponse(
         posts=[_post(post_id) for post_id in post_ids],
         extra=Extra(offset='', is_last=True),
     )
+    if api is not None:
+        api._page = page
     context = DownloadContext(
         author_name='author',
         downloader_session=cast('RetryClient', None),
@@ -136,7 +159,7 @@ def _use_case(
     )
     return DownloadAllPostUseCase(
         author_name='author',
-        boosty_api=cast('BoostyAPIClient', _FakeApi(page)),
+        boosty_api=cast('BoostyAPIClient', api if api is not None else _FakeApi(page)),
         destination=Path('unused'),
         download_context=context,
         skip_all_failures=skip_all_failures,
@@ -264,3 +287,90 @@ async def test_skip_all_failures_never_stops(
     assert len(calls) == 7, 'every post must be attempted despite the streak'
     summary = reporter.warnings[-1]
     assert 'failed to download (7)' in summary
+
+
+def _expired_error(post_id: str = 'p1') -> ApplicationFailedDownloadError:
+    error = ApplicationFailedDownloadError(
+        post_uuid=post_id, message='dead link', resource='r'
+    )
+    error.__cause__ = DownloadUnexpectedStatusError(
+        status=400, response_message='Bad Request', resource_url='https://cdn/x'
+    )
+    return error
+
+
+def _script_failing_then_ok(
+    monkeypatch: pytest.MonkeyPatch, failures: dict[str, Exception]
+) -> list[str]:
+    """Each scripted error fires once; later calls for that post succeed."""
+    calls: list[str] = []
+
+    async def scripted_execute(self: DownloadSinglePostUseCase) -> None:
+        calls.append(self.post_dto.id)
+        error = failures.pop(self.post_dto.id, None)
+        if error is not None:
+            raise error
+
+    monkeypatch.setattr(DownloadSinglePostUseCase, 'execute', scripted_execute)
+    return calls
+
+
+def _disable_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _no_sleep(_delay: float) -> None:
+        return
+
+    monkeypatch.setattr(post_retry_module.asyncio, 'sleep', _no_sleep)
+
+
+@pytest.mark.asyncio
+async def test_expired_link_is_refreshed_and_the_post_downloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Retrying the same dead url five times guaranteed a skipped post."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    api = _FakeApi()
+    calls = _script_failing_then_ok(monkeypatch, {'p1': _expired_error()})
+
+    await _use_case(['p1'], reporter, failed_logger, api=api).execute()
+
+    assert api.refetched == ['p1'], 'the post must be re-fetched exactly once'
+    assert calls == ['p1', 'p1'], 'the second try must run with the fresh post'
+    assert reporter.errors == [], 'a healed post must not be reported as failed'
+    assert any('refreshing the post' in message for message in reporter.warnings)
+
+
+@pytest.mark.asyncio
+async def test_expired_link_is_refreshed_only_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Endless refreshes would loop forever when 400 is not about expiry."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    api = _FakeApi()
+    _disable_retry_sleep(monkeypatch)
+    calls = _script_outcomes(monkeypatch, {'p1': _expired_error()})
+
+    await _use_case(['p1'], reporter, failed_logger, api=api).execute()
+
+    assert api.refetched == ['p1']
+    assert len(calls) == 5, 'the refresh consumes one slot of the 5-attempt budget'
+    assert any('Skip post after' in message for message in reporter.errors)
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_falls_back_to_the_normal_retry_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dead API must not add a second failure on top of the dead link."""
+    reporter = _FakeReporter()
+    failed_logger = _FakeFailedLogger()
+    api = _FakeApi(refetch_error=BoostyAPIUnknownError(500, 'api down'))
+    _disable_retry_sleep(monkeypatch)
+    calls = _script_outcomes(monkeypatch, {'p1': _expired_error()})
+
+    await _use_case(['p1'], reporter, failed_logger, api=api).execute()
+
+    assert api.refetched == ['p1']
+    assert len(calls) == 5
+    assert any('Skip post after' in message for message in reporter.errors)

--- a/test/unit/use_cases/download_specific_post_test.py
+++ b/test/unit/use_cases/download_specific_post_test.py
@@ -1,0 +1,196 @@
+"""The --post-url flow asks the API for one post instead of walking pages."""
+
+from __future__ import annotations
+
+import uuid as uuid_module
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.filtering import BoostyOkVideoType
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+)
+from boosty_downloader.src.application.use_cases.download_specific_post import (
+    DownloadPostByUrlUseCase,
+)
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPINoPostError,
+    BoostyAPIValidationError,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+
+if TYPE_CHECKING:
+    from aiohttp_retry import RetryClient
+
+    from boosty_downloader.src.cli.console_progress_reporter import ProgressReporter
+    from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+        BoostyAPIClient,
+    )
+    from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+        ExternalVideosDownloader,
+    )
+    from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import (
+        FailedDownloadsLogger,
+    )
+    from boosty_downloader.src.infrastructure.post_caching.post_cache import (
+        SQLitePostCache,
+    )
+
+POST_UUID = 'a2dd6942-7297-4340-a19f-d637fa8ef4de'
+POST_URL = f'https://boosty.to/author/posts/{POST_UUID}'
+
+
+class _FakeReporter:
+    """Collects messages instead of rendering rich output."""
+
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.infos: list[str] = []
+
+    def create_task(self, *args: object, **kwargs: object) -> uuid_module.UUID:
+        del args, kwargs
+        return uuid_module.uuid4()
+
+    def update_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def complete_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def success(self, message: str) -> None:
+        del message
+
+    def notice(self, message: str) -> None:
+        del message
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+    def warn(self, message: str) -> None:
+        del message
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+class _FakeApi:
+    """Answers get_single_post with a prepared post or a prepared error."""
+
+    def __init__(
+        self, post: PostDTO | None = None, error: Exception | None = None
+    ) -> None:
+        self._post = post
+        self._error = error
+        self.requests: list[tuple[str, str]] = []
+
+    async def get_single_post(self, author_name: str, post_id: str) -> PostDTO:
+        self.requests.append((author_name, post_id))
+        if self._error is not None:
+            raise self._error
+        assert self._post is not None
+        return self._post
+
+
+def _post(*, has_access: bool = True) -> PostDTO:
+    return PostDTO(
+        id=POST_UUID,
+        title='post',
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        has_access=has_access,
+        signed_query='',
+        data=[],
+    )
+
+
+def _use_case(api: _FakeApi, reporter: _FakeReporter) -> DownloadPostByUrlUseCase:
+    context = DownloadContext(
+        author_name='author',
+        downloader_session=cast('RetryClient', None),
+        external_videos_downloader=cast('ExternalVideosDownloader', None),
+        post_cache=cast('SQLitePostCache', None),
+        filters=[],
+        preferred_video_quality=BoostyOkVideoType.medium,
+        progress_reporter=cast('ProgressReporter', reporter),
+        failed_logger=cast('FailedDownloadsLogger', None),
+    )
+    return DownloadPostByUrlUseCase(
+        post_url=POST_URL,
+        boosty_api=cast('BoostyAPIClient', api),
+        destination=Path('unused'),
+        download_context=context,
+    )
+
+
+def _script_download(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    calls: list[str] = []
+
+    async def scripted_execute(self: DownloadSinglePostUseCase) -> None:
+        calls.append(self.post_dto.id)
+
+    monkeypatch.setattr(DownloadSinglePostUseCase, 'execute', scripted_execute)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_post_downloads_via_one_direct_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Walking 100-post pages made --post-url slow and stale-link-prone."""
+    reporter = _FakeReporter()
+    api = _FakeApi(post=_post())
+    calls = _script_download(monkeypatch)
+
+    await _use_case(api, reporter).execute()
+
+    assert api.requests == [('author', POST_UUID)]
+    assert calls == [POST_UUID]
+    assert reporter.errors == []
+
+
+@pytest.mark.asyncio
+async def test_missing_post_reports_not_found(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    reporter = _FakeReporter()
+    api = _FakeApi(error=BoostyAPINoPostError('author', POST_UUID))
+    calls = _script_download(monkeypatch)
+
+    await _use_case(api, reporter).execute()
+
+    assert calls == []
+    assert any('Failed to find' in message for message in reporter.errors)
+
+
+@pytest.mark.asyncio
+async def test_unparsable_post_asks_to_report(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misleading 'not found' would hide that the client needs an update."""
+    reporter = _FakeReporter()
+    api = _FakeApi(error=BoostyAPIValidationError(errors=[]))
+    calls = _script_download(monkeypatch)
+
+    await _use_case(api, reporter).execute()
+
+    assert calls == []
+    assert any('Please report this' in message for message in reporter.errors)
+
+
+@pytest.mark.asyncio
+async def test_no_access_post_is_not_downloaded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Downloading a paywalled post would save an empty preview as content."""
+    reporter = _FakeReporter()
+    api = _FakeApi(post=_post(has_access=False))
+    calls = _script_download(monkeypatch)
+
+    await _use_case(api, reporter).execute()
+
+    assert calls == []
+    assert any('no access' in message for message in reporter.errors)


### PR DESCRIPTION
## Summary

Signed download links live about 24 hours from the moment a listing page is fetched. On long runs they died mid-download: five retries hit the same dead url, the post went to the failed log, and five such posts in a row stopped the whole run. Now a dead link triggers one re-fetch of the post - fresh signatures, immediate retry. On top of that, `--post-url` uses the newly discovered single-post API endpoint: one direct request instead of walking the blog page by page.

## Problem

- A CDN 400/403 for an expired signature was flattened into a generic status error nobody inspected
- The per-post retry loop hit the same dead url five times in ~8 seconds - guaranteed failure
- An expired listing page means every post on it fails: the failure streak stopped the run as "systemic"
- The only cure was a manual rerun; the client had no way to ask the API for one post - `--post-url` linear-scanned 100-post pages

## Fix

- `get_single_post` on the API client: `GET blog/{author}/post/{id}`, one call, fresh signed urls; a missing post and an unparsable post raise distinct, clearly-worded errors
- `--post-url` asks for the post directly; a paywalled post without access now says so instead of downloading an empty preview
- `is_expired_link_error` recognizes a CDN 400/403 anywhere in the error cause chain
- The retry policy moved into its own `PostDownloadRetrier` (next to `FailureStreakBreaker`): attempt budget, backoff, and one expired-link refresh per post - a healed post touches neither the failed log nor the failure streak
- The refresh is spent even when it fails: a second 400 on fresh links means the problem is not expiry, and the old retry path takes over

## Before / After

**Before:** a run longer than the signature lifetime ends with "Skip post after 5 failed attempts" for every post of a stale page, then the systemic-failure stop; the user reruns by hand.

**After:** the log says `Signed links look expired, refreshing the post: ...`, the post re-fetches and downloads; `--post-url` starts downloading instantly with links fetched seconds ago.

## Verification

- Live `--debug` run of `--post-url`: the debug log shows exactly one API request - the direct `GET .../post/{id}` - and the post downloads
- 11 new unit tests: the client endpoint (parse, 404, validation details, 401), the direct `--post-url` flow (download, not found, unparsable, no access), and the refresh policy (healed on second try; refresh spent once; API failure falls back to the old retry path)
- Refactoring is invisible to the existing suite: all containment and failure-streak tests pass without a single expectation change; 124 tests total
- Full `task ci` green: checks, unit tests, 6 live integration tests, build

## Notes

- Expiry itself cannot be reproduced live in one session (needs a 24h-old link) - the trigger and the healing are pinned by unit tests on the real error types
- The listing page stays at 5 posts: the refresh is the safety net for the residual window, not a license for huge pages