### PR TITLE
[cli] Exit with a non-zero code when a run fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- The app now exits with code 1 on every handled error (author not found, bad credentials, network failure, stopped run) and 130 on Ctrl+C - scripts and cron jobs can finally tell a failed run from a successful one
 - `--post-url` finds the post with one direct API request instead of walking the whole blog page by page - instant start and download links that are always fresh; a paywalled post without access now says so instead of saving an empty preview
 
 ## 3.4.0

--- a/boosty_downloader/main.py
+++ b/boosty_downloader/main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import typer
 from aiohttp.client_exceptions import ClientError
 from sqlalchemy.exc import DatabaseError, IntegrityError, OperationalError
@@ -73,20 +75,24 @@ def entry_point() -> None:
             f"Author '{e.username}' not found. "
             'Username is the blog name from the author page URL: boosty.to/<username>'
         )
+        sys.exit(1)
     except BoostyAPIInvalidUsernameError as e:
         logger_instances.downloader_logger.error(
             f"'{e.username}' is not a valid username. "
             'Use the blog name from the author page URL (boosty.to/<username>), '
             'not an email'
         )
+        sys.exit(1)
     except BoostyAPIUnauthorizedError:
         logger_instances.downloader_logger.error(
             'Unauthorized: Bad credentials, please relogin and update your config file'
         )
+        sys.exit(1)
     except BoostyAPIUnknownError:
         logger_instances.downloader_logger.error(
             f'Unknown error occurred, please report this at GitHub issues of the project: {GITHUB_ISSUES_URL}'
         )
+        sys.exit(1)
     except BoostyAPIValidationError as e:
         details = '\n'.join(
             f'  - {line}' for line in format_validation_errors(e.errors)
@@ -97,17 +103,21 @@ def entry_point() -> None:
             '\n'
             f'{details}'
         )
+        sys.exit(1)
     except ApplicationCancelledError:
         logger_instances.downloader_logger.warning(
             'Download cancelled by user, see you later! 💘\n'
         )
+        sys.exit(130)
     except ApplicationTooManyFailuresError as e:
         logger_instances.downloader_logger.error(
             f'Download stopped after {e.streak} failed posts in a row - '
             'fix the cause and run the command again to resume.'
         )
+        sys.exit(1)
     except ClientError as e:
         report_network_error(e)
+        sys.exit(1)
     except (
         OperationalError,
         DatabaseError,
@@ -124,6 +134,7 @@ def entry_point() -> None:
             '👉 If this will still happen - please report it at GitHub issues:'
         )
         logger_instances.downloader_logger.info(f'👉 {GITHUB_ISSUES_URL}')
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/test/unit/cli/exit_codes_test.py
+++ b/test/unit/cli/exit_codes_test.py
@@ -1,0 +1,64 @@
+"""Automation reads $? - a failed run must not report success."""
+
+from __future__ import annotations
+
+import pytest
+
+from boosty_downloader import main as main_module
+from boosty_downloader.src.application.exceptions.application_errors import (
+    ApplicationCancelledError,
+    ApplicationTooManyFailuresError,
+)
+from boosty_downloader.src.infrastructure.boosty_api.core.client import (
+    BoostyAPINoUsernameError,
+    BoostyAPIUnauthorizedError,
+)
+
+
+def _raising_app(error: BaseException) -> object:
+    def fake_app() -> None:
+        raise error
+
+    return fake_app
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        BoostyAPINoUsernameError('nobody'),
+        BoostyAPIUnauthorizedError(),
+        ApplicationTooManyFailuresError(streak=5),
+    ],
+    ids=['no-username', 'unauthorized', 'too-many-failures'],
+)
+def test_handled_errors_exit_with_code_1(
+    monkeypatch: pytest.MonkeyPatch, error: BaseException
+) -> None:
+    """Cron and shell scripts treated every failure as success before."""
+    monkeypatch.setattr(main_module, 'typer_app', _raising_app(error))
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.entry_point()
+
+    assert exc_info.value.code == 1
+
+
+def test_user_cancel_exits_with_sigint_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ctrl+C is an interrupted run, not a success: 130 is the shell convention."""
+    monkeypatch.setattr(
+        main_module, 'typer_app', _raising_app(ApplicationCancelledError(post_uuid='p'))
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_module.entry_point()
+
+    assert exc_info.value.code == 130
+
+
+def test_clean_run_exits_quietly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Success must stay exit 0 - the fix touches only the failure branches."""
+    monkeypatch.setattr(main_module, 'typer_app', lambda: None)
+
+    main_module.entry_point()


### PR DESCRIPTION
## Summary

Every handled error printed a readable message and then exited with code 0 - for shell scripts, cron jobs and CI the app always "succeeded". Now every error branch exits 1, Ctrl+C exits 130, and a clean run still exits 0.

## Problem

- The top-level error ladder in `entry_point()` logged nicely and fell through: `$?` was 0 after "author not found", "Unauthorized", network failures and even the failure-streak stop
- `boosty-downloader download ... && next-step` happily ran `next-step` after a completely failed run

## Fix

- All nine error branches end with `sys.exit(1)`; messages are untouched
- `ApplicationCancelledError` (Ctrl+C) exits 130 - the shell convention for an interrupted run (128 + SIGINT)
- `sys.exit` instead of `typer.Exit` on purpose: the ladder lives outside the typer app, where `typer.Exit` would go unhandled

## Verification

- Live: `check --username <nonexistent>` exits 1 (was 0); `--version` exits 0
- 5 unit tests: parametrized errors exit 1, cancel exits 130, a clean run exits quietly
- Full `task check` and 129 unit tests green