### PR TITLE
[tests] Cover post cache round-trip and content filters

### DIFF
--- a/test/unit/post_caching/post_cache_test.py
+++ b/test/unit/post_caching/post_cache_test.py
@@ -1,0 +1,118 @@
+"""Characterization of the SQLite post cache (pre-refactoring safety net).
+
+Pins the cache's contract before the layering stages move it around:
+what counts as missing for fresh, partial and outdated posts, and how
+the cache behaves when its database file is broken.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy.exc import DatabaseError
+
+from boosty_downloader.src.application.filtering import DownloadContentTypeFilter
+from boosty_downloader.src.infrastructure.loggers.base import RichLogger
+from boosty_downloader.src.infrastructure.post_caching.post_cache import (
+    SQLitePostCache,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+ALL_PARTS = list(DownloadContentTypeFilter)
+UPDATED_AT = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+UPDATED_LATER = datetime(2026, 1, 2, 12, 0, tzinfo=timezone.utc)
+
+
+def _open_cache(destination: Path) -> SQLitePostCache:
+    return SQLitePostCache(destination=destination, logger=RichLogger('cache-test'))
+
+
+def test_unknown_post_needs_every_required_part(tmp_path: Path):
+    """A cache miss must not look like "already downloaded" - the post would be lost."""
+    with _open_cache(tmp_path) as cache:
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == ALL_PARTS
+
+
+def test_fully_cached_post_needs_nothing(tmp_path: Path):
+    """The point of the cache: a second run must not re-download anything."""
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, ALL_PARTS)
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == []
+
+
+def test_partial_download_reports_only_the_gap(tmp_path: Path):
+    """A filtered run must not re-fetch the parts an earlier run already saved."""
+    files = DownloadContentTypeFilter.files
+    post_content = DownloadContentTypeFilter.post_content
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, [files])
+        missing = cache.get_post_missing_parts('p1', UPDATED_AT, [files, post_content])
+    assert missing == [post_content]
+
+
+def test_author_update_invalidates_every_part(tmp_path: Path):
+    """An edited post must be re-downloaded in full even if it was fully cached."""
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, ALL_PARTS)
+        assert cache.get_post_missing_parts('p1', UPDATED_LATER, ALL_PARTS) == ALL_PARTS
+
+
+def test_second_run_extends_the_first(tmp_path: Path):
+    """Marking audio as downloaded must not erase the files flag from an earlier run."""
+    files = DownloadContentTypeFilter.files
+    audio = DownloadContentTypeFilter.audio
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, [files])
+        cache.cache_post('p1', UPDATED_AT, [audio])
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, [files, audio]) == []
+
+
+def test_cache_survives_reopen(tmp_path: Path):
+    """State must live in the file, not in the session: every run is a new process."""
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, ALL_PARTS)
+    with _open_cache(tmp_path) as cache:
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == []
+
+
+def test_clean_cache_forgets_everything(tmp_path: Path):
+    """clean-cache promises a fresh start - a surviving row would block re-download."""
+    with _open_cache(tmp_path) as cache:
+        cache.cache_post('p1', UPDATED_AT, ALL_PARTS)
+        cache.remove_cache_completely()
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == ALL_PARTS
+        # The reinitialized database must stay writable.
+        cache.cache_post('p2', UPDATED_AT, ALL_PARTS)
+        assert cache.get_post_missing_parts('p2', UPDATED_AT, ALL_PARTS) == []
+
+
+def test_outdated_schema_triggers_clean_reinit(tmp_path: Path):
+    """A hand-edited or ancient database must reset, not crash the run."""
+    db_file = tmp_path / SQLitePostCache.DEFAULT_CACHE_FILENAME
+    connection = sqlite3.connect(db_file)
+    connection.execute('CREATE TABLE post_cache (post_uuid TEXT PRIMARY KEY)')
+    connection.commit()
+    connection.close()
+
+    with _open_cache(tmp_path) as cache:
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == ALL_PARTS
+        cache.cache_post('p1', UPDATED_AT, ALL_PARTS)
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == []
+
+
+@pytest.mark.xfail(
+    reason='migrations run before the corruption check, so a non-SQLite cache '
+    'file crashes startup instead of reinitializing (audit 15.3)',
+    raises=DatabaseError,
+    strict=True,
+)
+def test_corrupted_file_triggers_clean_reinit(tmp_path: Path):
+    """Desired contract: any broken database resets instead of killing the run."""
+    (tmp_path / SQLitePostCache.DEFAULT_CACHE_FILENAME).write_bytes(b'not a database')
+    with _open_cache(tmp_path) as cache:
+        assert cache.get_post_missing_parts('p1', UPDATED_AT, ALL_PARTS) == ALL_PARTS

--- a/test/unit/use_cases/should_execute_test.py
+++ b/test/unit/use_cases/should_execute_test.py
@@ -1,0 +1,116 @@
+"""Characterization of the content-filter gate (pre-refactoring safety net).
+
+`_should_execute` decides whether a post is worth touching given the parts
+still missing. Pins the chunk-to-filter mapping before the use-case split.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.filtering import DownloadContentTypeFilter
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+)
+from boosty_downloader.src.domain.post import Post
+from boosty_downloader.src.domain.post_data_chunks import (
+    PostDataChunkAudio,
+    PostDataChunkBoostyVideo,
+    PostDataChunkExternalVideo,
+    PostDataChunkFile,
+    PostDataChunkImage,
+    PostDataChunkText,
+    PostDataChunkTextualList,
+)
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.application.di.download_context import DownloadContext
+    from boosty_downloader.src.domain.post import (
+        PostDataAllChunks,
+        PostDataAllChunksList,
+    )
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+
+NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+ALL_FILTERS = list(DownloadContentTypeFilter)
+
+
+def _use_case() -> DownloadSinglePostUseCase:
+    # The ctor only composes destination paths: the filter gate needs no context.
+    return DownloadSinglePostUseCase(
+        destination=Path('unused'),
+        post_dto=cast('PostDTO', None),
+        download_context=cast('DownloadContext', None),
+    )
+
+
+def _post_with(chunks: PostDataAllChunksList) -> Post:
+    return Post(
+        uuid='p1',
+        title='post',
+        created_at=NOW,
+        updated_at=NOW,
+        has_access=True,
+        signed_query='',
+        post_data_chunks=chunks,
+    )
+
+
+CHUNK_TO_FILTER = [
+    (PostDataChunkFile(url='u', filename='f.zip'), DownloadContentTypeFilter.files),
+    (PostDataChunkAudio(url='u', title='song'), DownloadContentTypeFilter.audio),
+    (
+        PostDataChunkBoostyVideo(id='v1', title='video', url='u', quality='high'),
+        DownloadContentTypeFilter.boosty_videos,
+    ),
+    (PostDataChunkExternalVideo(url='u'), DownloadContentTypeFilter.external_videos),
+    (PostDataChunkText(text_fragments=[]), DownloadContentTypeFilter.post_content),
+    (PostDataChunkImage(url='u'), DownloadContentTypeFilter.post_content),
+    (PostDataChunkTextualList(items=[]), DownloadContentTypeFilter.post_content),
+]
+
+
+@pytest.mark.parametrize(
+    ('chunk', 'expected_filter'),
+    CHUNK_TO_FILTER,
+    ids=[type(chunk).__name__ for chunk, _ in CHUNK_TO_FILTER],
+)
+def test_chunk_answers_only_to_its_filter(
+    chunk: PostDataAllChunks,
+    expected_filter: DownloadContentTypeFilter,
+):
+    """A drifted mapping silently skips content or downloads what was filtered out."""
+    use_case = _use_case()
+    post = _post_with([chunk])
+    for missing_part in DownloadContentTypeFilter:
+        should_run = use_case._should_execute(post, [missing_part])
+        assert should_run is (missing_part is expected_filter)
+
+
+def test_post_without_chunks_is_skipped():
+    """Nothing to download must mean "do not touch the disk at all"."""
+    use_case = _use_case()
+    assert use_case._should_execute(_post_with([]), ALL_FILTERS) is False
+
+
+def test_one_missing_part_is_enough_to_execute():
+    """A post with cached files but missing audio must still be processed."""
+    use_case = _use_case()
+    post = _post_with(
+        [
+            PostDataChunkFile(url='u', filename='f.zip'),
+            PostDataChunkAudio(url='u', title='song'),
+        ]
+    )
+    assert use_case._should_execute(post, [DownloadContentTypeFilter.audio]) is True
+
+
+def test_fully_cached_post_is_skipped():
+    """No missing parts must mean skip - or every cached post gets re-downloaded."""
+    use_case = _use_case()
+    post = _post_with([PostDataChunkFile(url='u', filename='f.zip')])
+    assert use_case._should_execute(post, []) is False


### PR DESCRIPTION
# [tests] Cover post cache round-trip and content filters

## Summary

Second PR of the test safety-net stage (stacked on #153, merge that one first). The cache and the content-filter gate are exactly what the upcoming layering refactoring will move around - this pins their behavior first. Coverage of `post_cache.py` goes from 31% to 97%, total from 69% to 73%.

## What is pinned

**SQLite post cache** (9 tests on `tmp_path`):

- an unknown post needs every required part - a miss must not look like "already downloaded"
- a fully cached post needs nothing, a partial one reports only the gap
- an author edit (newer `updated_at`) invalidates every part
- a second run extends the first: marking audio does not erase the files flag
- state survives closing and reopening the database - every run is a new process
- `clean-cache` really forgets everything and the database stays writable
- a database with an outdated schema resets cleanly instead of crashing

**Content-filter gate** (10 tests):

- the full 7x5 matrix: every chunk type answers only to its own filter
- a post with no chunks is skipped, one missing part is enough to execute, no missing parts means skip

## Known bug, documented as strict xfail

A cache file that is not SQLite at all (garbage bytes) crashes startup with `DatabaseError`: migrations in `__init__` run before the corruption check, so the reinit path never gets a chance. The test asserts the desired contract (reset instead of crash) and is marked `xfail(strict=True)`: today the run stays green, and the future fix will flip the test red until the mark is removed - a ready-made regression test.

## Verification

- `task ci` green: lint, format, pyright, 147 passed + 1 xfailed, build
- `task test:cov`: `post_cache.py` 97%, `models.py` 91%, TOTAL 73%

## Notes

- No changelog entry: tests only, nothing changes for users (`ci/skip-changelog`)
- Next PRs of the stage: golden tests for the mapper and HTML renderer, then local-server e2e + coverage gate
