### PR TITLE
[tests] Add golden tests for post mapper and HTML renderer

### DIFF
--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -1,0 +1,592 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <title>HTML Report</title>
+
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'light';
+            document.documentElement.classList.add(theme);
+        })();
+    </script>
+
+    <style>
+        html.light {
+            --bg-color: #ffffff;
+            --text-color: #000000;
+            --link-color: #1a0dab;
+            --content-bg-color: #fff;
+            --content-shadow: rgba(0, 0, 0, 0.1);
+            --border-color: #ccc;
+        }
+
+        html.dark {
+            --bg-color: #121212;
+            --text-color: #f0f0f0;
+            --link-color: #8ab4f8;
+            --content-bg-color: #1e1e1e;
+            --content-shadow: rgba(0, 0, 0, 0.7);
+            --border-color: #444;
+        }
+
+        /* Общие стили */
+        body {
+            font-family: 'Arial', sans-serif;
+            background-color: var(--bg-color);
+            color: var(--text-color);
+            line-height: 1.6;
+            margin: 0;
+            padding: 0;
+            max-width: 90%;
+            width: 950px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        a {
+            color: var(--link-color);
+            text-decoration: none;
+            font-weight: bold;
+        }
+
+        a:hover {
+            text-decoration: underline;
+        }
+
+        .content {
+            padding: 2rem;
+            background-color: var(--content-bg-color);
+            box-shadow: 0 0 12px var(--content-shadow);
+            margin-bottom: 3rem;
+            margin-top: 1.5rem;
+            border-radius: 8px;
+            transition: background-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+        }
+
+        p {
+            font-size: 1.2rem;
+            margin-bottom: 1.5rem;
+        }
+
+        h1,
+        h2,
+        h3,
+        h4,
+        h5,
+        h6 {
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+            font-weight: bold;
+            line-height: 1.3;
+        }
+
+        ul,
+        ol {
+            padding-left: 2rem;
+            margin-bottom: 1.5rem;
+        }
+
+        img {
+            display: block;
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            margin: 20px auto;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
+        }
+
+        video {
+            display: block;
+            margin: 2rem auto;
+            max-width: 100%;
+            border-radius: 6px;
+            box-shadow: 0 1px 6px rgba(0, 0, 0, 0.08);
+        }
+
+        .audio-player {
+            background: linear-gradient(135deg, var(--content-bg-color) 0%, var(--bg-color) 100%);
+            border: 1px solid var(--border-color);
+            border-radius: 12px;
+            padding: 1rem 1.5rem;
+            margin: 1.5rem auto;
+            max-width: 500px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+        }
+
+        .audio-title {
+            font-weight: 600;
+            font-size: 0.95rem;
+            margin-bottom: 0.75rem;
+            color: var(--text-color);
+            text-align: center;
+            word-break: break-word;
+        }
+
+        audio {
+            display: block;
+            width: 100%;
+        }
+
+        .new-paragraph {
+            margin-top: 2rem;
+        }
+
+        #theme-toggle {
+            position: fixed;
+            top: 0.5rem;
+            right: 0.5rem;
+            padding: 0.3rem 0.6rem;
+            background: none;
+            border: 1px solid var(--border-color);
+            border-radius: 0.5rem;
+            color: var(--text-color);
+            cursor: pointer;
+            font-size: 1rem;
+            user-select: none;
+            transition: color 0.3s ease, border-color 0.3s ease;
+            z-index: 1000;
+        }
+
+        #theme-toggle:hover {
+            background-color: var(--border-color);
+            color: var(--bg-color);
+        }
+    </style>
+</head>
+
+<body>
+    <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
+
+    <div class="content">
+        
+
+
+
+<h1>Welcome to my Boosty!</h1>
+
+
+
+
+
+
+
+    
+        
+            This post includes various elements: text, media, and lists.
+            
+        
+    
+
+
+
+
+
+
+
+
+
+    
+        
+            &lt;NEW_LINE_SYMBOL&gt;
+            
+        
+    
+
+
+
+
+
+
+
+
+
+    <em>
+        
+            Let&#39;s dive in below:
+            
+        </em>
+    
+
+
+
+
+
+
+
+
+<h2>Highlights</h2>
+
+
+
+
+
+
+
+    
+        
+            This paragraph contains a mix of 
+            
+        
+    
+
+
+
+
+
+
+
+
+<strong>
+    
+        
+            bold
+            
+        
+    </strong>
+
+
+
+
+
+
+
+
+
+    
+        
+            , 
+            
+        
+    
+
+
+
+
+
+
+
+
+
+    <em>
+        
+            italic
+            
+        </em>
+    
+
+
+
+
+
+
+
+
+
+    
+        
+            , and 
+            
+        
+    
+
+
+
+
+
+
+
+
+
+    
+        <u>
+            underlined
+            </u>
+        
+    
+
+
+
+
+
+
+
+
+
+    
+        
+             text. You can 
+            
+        
+    
+
+
+
+
+
+
+
+
+<a href="https://boosty.to/example">
+    
+        
+            <u>
+                click here
+                </u>
+            
+        
+</a>
+
+
+
+
+
+
+
+
+
+    
+        
+             to support me.
+            
+        
+    
+
+
+
+
+
+
+
+    <ul>
+        
+        
+        <li>
+    
+    
+
+
+
+
+
+    
+        
+            📌 What you&#39;ll get inside:
+            
+        
+    
+
+
+
+
+    
+    
+    
+        <ul>
+            
+            
+            <li>
+    
+    
+
+
+
+
+
+    
+        
+            High-quality images
+            
+        
+    
+
+
+
+
+    
+    
+</li>
+            
+            <li>
+    
+    
+
+
+
+
+
+    
+        
+            Source files (PSD, RAW)
+            
+        
+    
+
+
+
+
+    
+    
+</li>
+            
+            <li>
+    
+    
+
+
+
+
+
+    
+        
+            Bonus video content
+            
+        
+    
+
+
+
+
+    
+    
+    
+        <ul>
+            
+            
+            <li>
+    
+    
+
+
+
+
+
+    
+        
+            Behind the scenes
+            
+        
+    
+
+
+
+
+    
+    
+</li>
+            
+            <li>
+    
+    
+
+
+
+
+
+    
+        
+            Unreleased footage
+            
+        
+    
+
+
+
+
+    
+    
+</li>
+            
+            
+    </ul>
+    
+    
+</li>
+            
+            
+    </ul>
+    
+    
+</li>
+        
+        
+</ul>
+
+<img src="https://example.com/banner.jpg" alt="Image" style="max-width: 100%;">
+<video controls>
+    <source src="https://example.com/video.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+</video>
+<video controls>
+    <source src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" type="video/mp4">
+    Your browser does not support the video tag.
+</video>
+
+
+
+
+
+
+    
+        
+            &lt;NEW_LINE_SYMBOL&gt;
+            
+        
+    
+
+
+
+
+
+
+
+<h2>Thanks for reading!</h2>
+
+
+
+
+
+
+
+    
+        
+            Feel free to leave a comment or suggestion below.
+            
+        
+    
+
+
+
+
+<a href="files/release-notes.zip" download>release <v2> & notes.zip</a>
+<div class="audio-player">
+    
+    <div class="audio-title">fixture-song.mp3</div>
+    
+    <audio controls>
+        <source src="audio/fixture-song.mp3">
+        Your browser does not support the audio tag.
+    </audio>
+</div>
+    </div>
+
+    <script>
+        const toggleBtn = document.getElementById('theme-toggle');
+        toggleBtn.textContent = document.documentElement.classList.contains('dark') ? '🌙' : '☀';
+
+        toggleBtn.onclick = function () {
+            const html = document.documentElement;
+            const current = html.classList.contains('dark') ? 'dark' : 'light';
+            const next = current === 'dark' ? 'light' : 'dark';
+
+            html.classList.remove(current);
+            html.classList.add(next);
+            localStorage.setItem('theme', next);
+
+            this.textContent = next === 'dark' ? '🌙' : '☀';
+        };
+    </script>
+</body>
+
+</html>

--- a/test/fixtures/single_post.json
+++ b/test/fixtures/single_post.json
@@ -1,0 +1,275 @@
+{
+  "donators": {
+    "data": [],
+    "extra": {
+      "isLast": true
+    }
+  },
+  "donations": 0,
+  "hasAccess": true,
+  "intId": 101,
+  "price": 0,
+  "int_id": 101,
+  "currencyDonations": {
+    "EUR": 0,
+    "RUB": 0,
+    "USD": 0
+  },
+  "isBlocked": false,
+  "isCommentsDenied": false,
+  "user": {
+    "avatarUrl": "https://images.example/avatar.png",
+    "blogUrl": "example_author",
+    "currency": "RUB",
+    "flags": {
+      "showPostDonations": false
+    },
+    "hasAvatar": true,
+    "id": 424242,
+    "isOfficial": false,
+    "name": "Example Author"
+  },
+  "reactionCounters": [],
+  "data": [
+    {
+      "type": "text",
+      "content": "[\"Hello from the fixture post!\", \"unstyled\", []]",
+      "modificator": ""
+    },
+    {
+      "content": "",
+      "modificator": "BLOCK_END",
+      "type": "text"
+    },
+    {
+      "type": "text",
+      "content": "[\"\", \"unstyled\", []]",
+      "modificator": ""
+    },
+    {
+      "type": "text",
+      "modificator": "BLOCK_END",
+      "content": ""
+    },
+    {
+      "type": "text",
+      "content": "[\"\", \"unstyled\", []]",
+      "modificator": ""
+    },
+    {
+      "content": "",
+      "modificator": "BLOCK_END",
+      "type": "text"
+    },
+    {
+      "height": 208,
+      "id": "10000000-0000-4000-8000-000000000201",
+      "isInvalid": null,
+      "size": 10941,
+      "rendition": "",
+      "url": "https://images.example/image/10000000-0000-4000-8000-000000000201",
+      "width": 1216,
+      "type": "image"
+    },
+    {
+      "url": "https://cdn.example/file/10000000-0000-4000-8000-000000000301",
+      "title": "fixture-archive.zip",
+      "type": "file",
+      "complete": true,
+      "size": 4444053,
+      "id": "10000000-0000-4000-8000-000000000301",
+      "isInvalid": null
+    },
+    {
+      "type": "ok_video",
+      "url": "",
+      "playerUrls": [
+        {
+          "url": "https://video.example/dash.mpd?fake-sig",
+          "type": "dash"
+        },
+        {
+          "url": "https://video.example/low.mp4?fake-sig",
+          "type": "low"
+        },
+        {
+          "type": "live_cmaf",
+          "url": ""
+        },
+        {
+          "url": "",
+          "type": "live_dash"
+        },
+        {
+          "type": "dash_uni",
+          "url": ""
+        },
+        {
+          "url": "",
+          "type": "live_playback_hls"
+        },
+        {
+          "url": "https://video.example/medium.mp4?fake-sig",
+          "type": "medium"
+        },
+        {
+          "type": "lowest",
+          "url": "https://video.example/lowest.mp4?fake-sig"
+        },
+        {
+          "type": "live_hls",
+          "url": ""
+        },
+        {
+          "url": "https://video.example/hls.m3u8?fake-sig",
+          "type": "hls"
+        },
+        {
+          "type": "tiny",
+          "url": "https://video.example/tiny.mp4?fake-sig"
+        },
+        {
+          "type": "ondemand_dash",
+          "url": ""
+        },
+        {
+          "url": "",
+          "type": "quad_hd"
+        },
+        {
+          "url": "",
+          "type": "high"
+        },
+        {
+          "url": "",
+          "type": "full_hd"
+        },
+        {
+          "url": "",
+          "type": "ultra_hd"
+        },
+        {
+          "type": "live_playback_dash",
+          "url": ""
+        },
+        {
+          "url": "",
+          "type": "ondemand_hls"
+        },
+        {
+          "type": "live_ondemand_hls",
+          "url": ""
+        }
+      ],
+      "duration": 198,
+      "isInvalid": null,
+      "defaultPreview": "https://images.example/preview/default",
+      "viewsCounter": 0,
+      "timeCode": 5,
+      "title": "Fixture video",
+      "uploadStatus": "ok",
+      "preview": "https://images.example/preview/full",
+      "status": "ok",
+      "complete": true,
+      "width": 654,
+      "showViewsCounter": true,
+      "failoverHost": "video-failover.example",
+      "vid": "9000000000000",
+      "id": "10000000-0000-4000-8000-000000000400",
+      "height": 480
+    },
+    {
+      "type": "audio_file",
+      "duration": 3,
+      "viewsCounter": 0,
+      "showViewsCounter": true,
+      "title": "fixture-song.mp3",
+      "fileType": "MP3",
+      "artist": "Example Artist",
+      "size": 24494,
+      "isInvalid": null,
+      "track": "",
+      "complete": true,
+      "uploadStatus": null,
+      "timeCode": 3,
+      "album": "",
+      "id": "10000000-0000-4000-8000-000000000500",
+      "url": "https://cdn.example/audio/10000000-0000-4000-8000-000000000500"
+    },
+    {
+      "type": "hologram_message",
+      "id": "10000000-0000-4000-8000-000000000600",
+      "complete": true
+    }
+  ],
+  "isWaitingVideo": false,
+  "teaser": [],
+  "frame": {
+    "next": {
+      "title": "Trying audio",
+      "publishTime": 1767584516,
+      "id": "369e29ef-ae70-412c-9278-15a355a1f15f"
+    },
+    "previous": null
+  },
+  "title": "Fixture post with every content type",
+  "count": {
+    "likes": 0,
+    "comments": 0,
+    "reactions": {}
+  },
+  "isPinned": false,
+  "contentCounters": [
+    {
+      "count": 1,
+      "size": 4444053,
+      "type": "file"
+    },
+    {
+      "type": "text",
+      "size": 0,
+      "count": 6
+    },
+    {
+      "type": "image",
+      "size": 10941,
+      "count": 1
+    },
+    {
+      "size": 0,
+      "type": "ok_video",
+      "count": 1
+    }
+  ],
+  "isPublished": true,
+  "id": "00000000-0000-4000-8000-000000000001",
+  "isMarketing": false,
+  "publishTime": 1750000000,
+  "showViewsCounter": true,
+  "createdAt": 1750000000,
+  "signedQuery": "?fake-signed-query",
+  "isLiked": false,
+  "isRecord": false,
+  "comments": {
+    "data": [],
+    "extra": {
+      "isFirst": true,
+      "isLast": true
+    }
+  },
+  "reactionsDisabled": false,
+  "updatedAt": 1750100000,
+  "tags": [],
+  "isDeleted": false,
+  "promo": null,
+  "hasAdultContent": false,
+  "sortOrder": 1767499341,
+  "currencyPrices": {
+    "EUR": 0,
+    "RUB": 0,
+    "USD": 0
+  },
+  "isShowcaseVisible": false,
+  "bundleIds": [],
+  "advertiserInfo": null
+}

--- a/test/fixtures/single_post_domain.json
+++ b/test/fixtures/single_post_domain.json
@@ -1,0 +1,99 @@
+{
+  "incomplete_content_types": [],
+  "post": {
+    "created_at": "2025-06-15T15:06:40+00:00",
+    "has_access": true,
+    "post_data_chunks": [
+      {
+        "text_fragments": [
+          {
+            "header_level": 0,
+            "link_url": null,
+            "style": {
+              "bold": false,
+              "italic": false,
+              "underline": false
+            },
+            "text": "Hello from the fixture post!"
+          }
+        ]
+      },
+      {
+        "text_fragments": [
+          {
+            "header_level": 0,
+            "link_url": null,
+            "style": {
+              "bold": false,
+              "italic": false,
+              "underline": false
+            },
+            "text": "\n"
+          }
+        ]
+      },
+      {
+        "text_fragments": []
+      },
+      {
+        "text_fragments": [
+          {
+            "header_level": 0,
+            "link_url": null,
+            "style": {
+              "bold": false,
+              "italic": false,
+              "underline": false
+            },
+            "text": "\n"
+          }
+        ]
+      },
+      {
+        "text_fragments": []
+      },
+      {
+        "text_fragments": [
+          {
+            "header_level": 0,
+            "link_url": null,
+            "style": {
+              "bold": false,
+              "italic": false,
+              "underline": false
+            },
+            "text": "\n"
+          }
+        ]
+      },
+      {
+        "url": "https://images.example/image/10000000-0000-4000-8000-000000000201"
+      },
+      {
+        "filename": "fixture-archive.zip",
+        "url": "https://cdn.example/file/10000000-0000-4000-8000-000000000301?fake-signed-query"
+      },
+      {
+        "id": "10000000-0000-4000-8000-000000000400",
+        "quality": "medium",
+        "title": "Fixture video",
+        "url": "https://video.example/medium.mp4?fake-sig"
+      },
+      {
+        "title": "fixture-song.mp3",
+        "url": "https://cdn.example/audio/10000000-0000-4000-8000-000000000500"
+      }
+    ],
+    "signed_query": "?fake-signed-query",
+    "title": "Fixture post with every content type",
+    "updated_at": "2025-06-16T18:53:20+00:00",
+    "uuid": "00000000-0000-4000-8000-000000000001"
+  },
+  "stream_only_videos": [],
+  "unknown_content": [
+    {
+      "path": "data[10].type",
+      "raw": "hologram_message"
+    }
+  ]
+}

--- a/test/unit/html_generator/html_templates_test.py
+++ b/test/unit/html_generator/html_templates_test.py
@@ -1,7 +1,10 @@
+import os
 from pathlib import Path
 
 from boosty_downloader.src.infrastructure.html_generator.models import (
+    HtmlGenAudio,
     HtmlGenChunk,
+    HtmlGenFile,
     HtmlGenImage,
     HtmlGenList,
     HtmlGenText,
@@ -16,8 +19,9 @@ from boosty_downloader.src.infrastructure.html_generator.renderer import (
 )
 
 
-def test_html_generator_templates(tmp_path: Path):
-    chunks: list[HtmlGenChunk] = [
+def _showcase_chunks() -> list[HtmlGenChunk]:
+    """Fresh chunks per call: the renderer mutates video and audio urls in place."""
+    return [
         HtmlGenText(
             text_fragments=[
                 HtmlTextFragment(text='Welcome to my Boosty!', header_level=1),
@@ -145,7 +149,18 @@ def test_html_generator_templates(tmp_path: Path):
                 ),
             ]
         ),
+        HtmlGenFile(
+            # The markup in the name pins current renderer behavior: file links
+            # are built with a plain f-string, the name goes into HTML unescaped.
+            url='files/release-notes.zip',
+            filename='release <v2> & notes.zip',
+        ),
+        HtmlGenAudio(title='fixture-song.mp3', url='audio/fixture-song.mp3'),
     ]
+
+
+def test_html_generator_templates(tmp_path: Path):
+    chunks = _showcase_chunks()
 
     data = render_html(chunks)
 
@@ -156,3 +171,20 @@ def test_html_generator_templates(tmp_path: Path):
     assert test_output_file.exists()
     assert test_output_file.read_text(encoding='utf-8') == data
     assert len(data) > 0
+
+
+GOLDEN_FILE = Path(__file__).parents[2] / 'fixtures' / 'rendered_post.html'
+
+
+def test_showcase_matches_the_pinned_golden_html():
+    """A refactoring must not change a single rendered byte unnoticed.
+
+    An intentional template change regenerates the file:
+    UPDATE_GOLDEN=1 task test - then review the golden diff.
+    """
+    html = render_html(_showcase_chunks())
+
+    if os.environ.get('UPDATE_GOLDEN') == '1':
+        GOLDEN_FILE.write_text(html, encoding='utf-8')
+
+    assert html == GOLDEN_FILE.read_text(encoding='utf-8')

--- a/test/unit/mappers/post_mapper_golden_test.py
+++ b/test/unit/mappers/post_mapper_golden_test.py
@@ -1,0 +1,58 @@
+"""Golden test: a real post's JSON maps to a pinned domain snapshot.
+
+The fixture is a captured API response of one post (identifiers, urls and
+texts replaced with fakes), extended with an audio chunk and an unknown-type
+chunk. The snapshot pins the whole DTO-to-domain mapping, including what
+lands in unknown_content. An intentional mapping change regenerates it:
+UPDATE_GOLDEN=1 task test - then review the golden diff.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import fields, is_dataclass
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+
+from boosty_downloader.src.application.filtering import BoostyOkVideoType
+from boosty_downloader.src.application.mappers.post_mapper import (
+    map_post_dto_to_domain,
+)
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+
+FIXTURES = Path(__file__).parents[2] / 'fixtures'
+FIXTURE_FILE = FIXTURES / 'single_post.json'
+GOLDEN_FILE = FIXTURES / 'single_post_domain.json'
+
+
+def _snapshot(value: object) -> object:
+    """Turn the mapping result into plain JSON-friendly data, deterministically."""
+    if is_dataclass(value) and not isinstance(value, type):
+        return {f.name: _snapshot(getattr(value, f.name)) for f in fields(value)}
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.name
+    if isinstance(value, list | tuple):
+        return [_snapshot(item) for item in value]
+    if isinstance(value, set | frozenset):
+        return sorted((_snapshot(item) for item in value), key=json.dumps)
+    return value
+
+
+def test_real_post_shape_maps_to_the_pinned_domain():
+    """A silent mapping change becomes wrong or missing files on disk."""
+    dto = PostDTO.model_validate(json.loads(FIXTURE_FILE.read_text(encoding='utf-8')))
+
+    result = map_post_dto_to_domain(dto, BoostyOkVideoType.medium)
+
+    snapshot = (
+        json.dumps(_snapshot(result), ensure_ascii=False, indent=2, sort_keys=True)
+        + '\n'
+    )
+    if os.environ.get('UPDATE_GOLDEN') == '1':
+        GOLDEN_FILE.write_text(snapshot, encoding='utf-8')
+
+    assert snapshot == GOLDEN_FILE.read_text(encoding='utf-8')


### PR DESCRIPTION
# [tests] Add golden tests for post mapper and HTML renderer

## Summary

Third PR of the test safety-net stage (stacked on #154, merge order: #153 -> #154 -> this). Golden files pin the two transformations the upcoming refactoring touches hardest: DTO-to-domain mapping and HTML rendering. From now on neither can change a field or a byte unnoticed - the test goes red and the golden diff shows up in review.

## What is in here

- `test/fixtures/single_post.json` - a captured real API response of one post, sanitized: all ids, urls and texts replaced with fakes, zero real identifiers (checked). The real emptiness pattern of `playerUrls` is preserved: progressive mp4 + dash/hls set, ondemand/live/hd empty. Extended with an audio chunk and an unknown-type chunk
- `test/fixtures/single_post_domain.json` - the pinned mapping result: 11 DTO chunks -> 10 domain chunks + unknown content recorded with its exact path (`data[10].type`)
- `test/fixtures/rendered_post.html` - the pinned byte-for-byte render of a fixed chunk showcase
- The showcase moved into a `_showcase_chunks()` helper (fresh list per call - the renderer mutates video/audio urls in place) and now covers file and audio chunks too

`UPDATE_GOLDEN=1 task test` regenerates both goldens for intentional changes - the golden diff is then reviewed like any code.

## The goldens already document three audit findings

- image and audio urls get no `signed_query` appended (files do) - a 403 risk on protected content
- a file name goes into HTML unescaped (the showcase pins `release <v2> & notes.zip` raw)
- external video links render with hardcoded `type="video/mp4"`

The upcoming render-fix PR will change these lines - visibly, as golden diffs.

## Verification

- `task ci` green: lint, format, pyright, 149 passed + 1 xfailed, build
- Leak check on fixtures: author name, boosty hostnames, real post/chunk ids - 0 hits

## Notes

- No changelog entry: tests only (`ci/skip-changelog`)
- Last PR of the stage after this: local-server e2e + CLI smoke + coverage gate
