### PR TITLE
[renderer] Fix rendered post look: title, numbering, escaping, clean markup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Fixed
 
+- Rendered posts look right in the browser and in the editor: the tab shows the post title instead of "HTML Report", numbered lists keep their numbering instead of turning into bullets, and post.html itself is ~2.5x smaller with properly indented markup instead of walls of blank lines
+- A file whose name contains HTML markup (like `report <final>.zip`) no longer breaks the post page - names are escaped now
+- External videos saved as webm/mkv get a matching MIME type in the player instead of a hardcoded mp4 one
+- Already downloaded posts keep their old HTML: the new rendering applies to new and updated posts (a full re-render command is planned separately)
+
 - Long runs no longer die on expired download links: when the CDN rejects a link that lived past its ~24-hour signature, the post is re-fetched from the API once and the download retries with fresh links - no manual rerun needed
 - New Boosty video url types `ondemand_dash` / `ondemand_hls` no longer trigger the "please report this at GitHub" warning - the client knows them now
 - A video that offers only streaming manifests (hls/dash/live) is skipped with an honest "streams are not supported yet" warning and retried on the next run; a manifest can no longer end up on disk pretending to be a video file

--- a/boosty_downloader/src/application/mappers/html_converter.py
+++ b/boosty_downloader/src/application/mappers/html_converter.py
@@ -66,8 +66,11 @@ def convert_list_to_html(chunk: PostDataChunkTextualList) -> HtmlGenList:
         return HtmlListItem(data=data, nested_items=nested_items)
 
     items = [convert_list_item(item) for item in chunk.items]
-    # Default to unordered list since the domain model doesn't have style
-    style = HtmlListStyle.UNORDERED
+    style = (
+        HtmlListStyle.ORDERED
+        if chunk.style is PostDataChunkTextualList.ListStyle.ordered
+        else HtmlListStyle.UNORDERED
+    )
 
     return HtmlGenList(items=items, style=style)
 

--- a/boosty_downloader/src/application/mappers/list.py
+++ b/boosty_downloader/src/application/mappers/list.py
@@ -24,6 +24,7 @@ from boosty_downloader.src.domain.post_data_chunks import (
 )
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_list import (
     BoostyListItemType,
+    BoostyListStyle,
     BoostyPostDataListDTO,
     BoostyPostDataListItemDTO,
 )
@@ -67,4 +68,12 @@ def to_domain_list_chunk(post_list: BoostyPostDataListDTO) -> PostDataChunkTextu
     # Convert all items
     domain_items = [convert_list_item(api_item) for api_item in post_list.items]
 
-    return PostDataChunkTextualList(items=domain_items)
+    # Only 'ordered' switches the numbering on: an absent or unknown style
+    # falls back to a plain bullet list instead of failing the post.
+    style = (
+        PostDataChunkTextualList.ListStyle.ordered
+        if post_list.style is BoostyListStyle.ordered
+        else PostDataChunkTextualList.ListStyle.unordered
+    )
+
+    return PostDataChunkTextualList(items=domain_items, style=style)

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -217,7 +217,13 @@ class DownloadSinglePostUseCase:
 
             if DownloadContentTypeFilter.post_content in missing_parts:
                 try:
-                    render_html_to_file(post_html, out_path=self.post_file_path)
+                    render_html_to_file(
+                        post_html,
+                        out_path=self.post_file_path,
+                        # Empty titles happen: the folder name always carries
+                        # the date, the title and the id.
+                        page_title=post.title.strip() or self.destination.name,
+                    )
                 except CancelledError:
                     self.post_file_path.unlink(missing_ok=True)
                     raise

--- a/boosty_downloader/src/domain/post_data_chunks.py
+++ b/boosty_downloader/src/domain/post_data_chunks.py
@@ -25,7 +25,7 @@ class PostDataChunkImage:
 
 @dataclass
 class PostDataChunkText:
-    """
+    r"""
     Represent a textual data chunk within a post.
 
     It can contain multiple text fragments, each with optional styling and links.
@@ -36,7 +36,7 @@ class PostDataChunkText:
                 PostDataChunkText.TextFragment(text="Hello, world!", bold=True),
                 PostDataChunkText.TextFragment(text="Visit Boosty", link_data="https://boosty.com", header_level=1),
                 PostDataChunkText.TextFragment(text="This is a normal text."),
-                PostDataChunkText.TextFragment(text="<NEW_LINE_SYMBOL>"),
+                PostDataChunkText.TextFragment(text="\n"),
             ]
     """
 

--- a/boosty_downloader/src/domain/post_data_chunks.py
+++ b/boosty_downloader/src/domain/post_data_chunks.py
@@ -158,3 +158,4 @@ class PostDataChunkTextualList:
         unordered = 'unordered'
 
     items: list[ListItem]
+    style: ListStyle = ListStyle.unordered

--- a/boosty_downloader/src/infrastructure/html_generator/renderer.py
+++ b/boosty_downloader/src/infrastructure/html_generator/renderer.py
@@ -72,14 +72,18 @@ def render_html_chunk(chunk: HtmlGenChunk) -> str:
             return env.get_template('file.html').render(file=chunk)
 
 
-def render_html(chunks: list[HtmlGenChunk]) -> str:
-    """Render a list of HTML chunks to HTML."""
+def render_html(chunks: list[HtmlGenChunk], page_title: str) -> str:
+    """Render a list of HTML chunks to a full HTML page."""
     rendered = [render_html_chunk(chunk) for chunk in chunks]
-    return env.get_template('base.html').render(content='\n'.join(rendered))
+    return env.get_template('base.html').render(
+        content='\n'.join(rendered), title=page_title
+    )
 
 
-def render_html_to_file(chunks: list[HtmlGenChunk], out_path: Path) -> None:
+def render_html_to_file(
+    chunks: list[HtmlGenChunk], out_path: Path, page_title: str
+) -> None:
     """Render HTML chunks to HTML file."""
-    html = render_html(chunks)
+    html = render_html(chunks, page_title)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(html, encoding='utf-8')

--- a/boosty_downloader/src/infrastructure/html_generator/renderer.py
+++ b/boosty_downloader/src/infrastructure/html_generator/renderer.py
@@ -75,8 +75,11 @@ def render_html_chunk(chunk: HtmlGenChunk) -> str:
 def render_html(chunks: list[HtmlGenChunk], page_title: str) -> str:
     """Render a list of HTML chunks to a full HTML page."""
     rendered = [render_html_chunk(chunk) for chunk in chunks]
+    # Empty chunks (e.g. text with no fragments) would otherwise leave
+    # blank lines between their neighbours.
+    parts = [part.strip('\n') for part in rendered if part.strip()]
     return env.get_template('base.html').render(
-        content='\n'.join(rendered), title=page_title
+        content='\n'.join(parts), title=page_title
     )
 
 

--- a/boosty_downloader/src/infrastructure/html_generator/renderer.py
+++ b/boosty_downloader/src/infrastructure/html_generator/renderer.py
@@ -6,6 +6,7 @@ You can also dump the rendered HTML to a file.
 Current implementation uses Jinja2 templates to render HTML with a little styling.
 """
 
+import mimetypes
 from pathlib import Path
 
 from jinja2 import Environment, PackageLoader, select_autoescape
@@ -28,7 +29,22 @@ env = Environment(
         'boosty_downloader.src.infrastructure.html_generator', 'templates'
     ),
     autoescape=select_autoescape(['html']),
+    # Swallow the newlines and indentation of {% ... %} lines: without this
+    # every template control line leaks blank lines into the rendered page.
+    trim_blocks=True,
+    lstrip_blocks=True,
 )
+
+
+def _media_src(url: str) -> str:
+    """Media urls are file paths relative to the post folder: web slashes only."""
+    return str(url).replace('\\', '/')
+
+
+def _media_mime_type(url: str) -> str | None:
+    """MIME by file extension; None omits the attribute so the browser sniffs."""
+    mime_type, _ = mimetypes.guess_type(_media_src(url))
+    return mime_type
 
 
 def render_html_chunk(chunk: HtmlGenChunk) -> str:
@@ -39,17 +55,21 @@ def render_html_chunk(chunk: HtmlGenChunk) -> str:
         case HtmlGenImage():
             return env.get_template('image.html').render(image=chunk)
         case HtmlGenVideo():
-            chunk.url = str(chunk.url).replace('\\', '/')
-            return env.get_template('video.html').render(video=chunk)
+            return env.get_template('video.html').render(
+                video=chunk,
+                src=_media_src(chunk.url),
+                mime_type=_media_mime_type(chunk.url),
+            )
         case HtmlGenAudio():
-            chunk.url = str(chunk.url).replace('\\', '/')
-            return env.get_template('audio.html').render(audio=chunk)
+            return env.get_template('audio.html').render(
+                audio=chunk, src=_media_src(chunk.url)
+            )
         case HtmlGenList():
             return env.get_template('list.html').render(
                 lst=chunk, render_chunk=render_html_chunk
             )
         case HtmlGenFile():
-            return f'<a href="{chunk.url}" download>{chunk.filename}</a>'
+            return env.get_template('file.html').render(file=chunk)
 
 
 def render_html(chunks: list[HtmlGenChunk]) -> str:

--- a/boosty_downloader/src/infrastructure/html_generator/templates/audio.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/audio.html
@@ -3,7 +3,7 @@
     <div class="audio-title">{{ audio.title }}</div>
     {% endif %}
     <audio controls>
-        <source src="{{ audio.url }}">
+        <source src="{{ src }}">
         Your browser does not support the audio tag.
     </audio>
 </div>

--- a/boosty_downloader/src/infrastructure/html_generator/templates/base.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/base.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>HTML Report</title>
+    <title>{{ title }}</title>
 
     <script>
         (function () {

--- a/boosty_downloader/src/infrastructure/html_generator/templates/file.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/file.html
@@ -1,0 +1,1 @@
+<a href="{{ file.url }}" download>{{ file.filename }}</a>

--- a/boosty_downloader/src/infrastructure/html_generator/templates/list.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/list.html
@@ -2,14 +2,14 @@
 {% macro render_item(item) %}
 <li>
 {% for txt in item.data %}
-{{ render_chunk(txt) | trim | safe }}
+{{ render_chunk(txt) | trim | indent(4, first=True) | safe }}
 {% endfor %}
 {% if item.nested_items %}
-<{{ tag }}>
+    <{{ tag }}>
 {% for nested in item.nested_items %}
-{{ render_item(nested) | trim | indent(4, first=True) | safe }}
+{{ render_item(nested) | trim | indent(8, first=True) | safe }}
 {% endfor %}
-</{{ tag }}>
+    </{{ tag }}>
 {% endif %}
 </li>
 {% endmacro %}

--- a/boosty_downloader/src/infrastructure/html_generator/templates/list.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/list.html
@@ -1,36 +1,20 @@
-{% macro render_item(item) -%}
+{% set tag = 'ol' if lst.style.value == 'ordered' else 'ul' %}
+{% macro render_item(item) %}
 <li>
-    {% for txt in item.data %}
-    {{ render_chunk(txt) | safe }}
-    {% endfor %}
-    {% if item.nested_items %}
-    {% if lst.style.value == 'ordered' %}
-    <ol>
-        {% else %}
-        <ul>
-            {% endif %}
-            {% for nested in item.nested_items %}
-            {{ render_item(nested) }}
-            {% endfor %}
-            {% if lst.style.value == 'ordered' %}
-    </ol>
-    {% else %}
-    </ul>
-    {% endif %}
-    {% endif %}
-</li>
-{%- endmacro %}
-
-{% if lst.style.value == 'ordered' %}
-<ol>
-    {% else %}
-    <ul>
-        {% endif %}
-        {% for item in lst.items %}
-        {{ render_item(item) }}
-        {% endfor %}
-        {% if lst.style.value == 'ordered' %}
-</ol>
-{% else %}
-</ul>
+{% for txt in item.data %}
+{{ render_chunk(txt) | trim | safe }}
+{% endfor %}
+{% if item.nested_items %}
+<{{ tag }}>
+{% for nested in item.nested_items %}
+{{ render_item(nested) | trim | indent(4, first=True) | safe }}
+{% endfor %}
+</{{ tag }}>
 {% endif %}
+</li>
+{% endmacro %}
+<{{ tag }}>
+{% for item in lst.items %}
+{{ render_item(item) | trim | indent(4, first=True) | safe }}
+{% endfor %}
+</{{ tag }}>

--- a/boosty_downloader/src/infrastructure/html_generator/templates/text.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/text.html
@@ -1,31 +1,19 @@
 {% for frag in text.text_fragments %}
-{% set lvl = frag.header_level|default(0)|int %}
+{% set lvl = frag.header_level | default(0) | int %}
 {% if lvl > 0 %}
 {% if lvl > 6 %}{% set lvl = 6 %}{% endif %}
 <h{{ lvl }}>{{ frag.text }}</h{{ lvl }}>
-{% else %}
-{% if frag.text in ['\n', '\r\n'] %}
+{% elif frag.text in ['\n', '\r\n'] %}
 <br>
 {% else %}
-{% if frag.link_url %}
-<a href="{{ frag.link_url|e }}">
-    {% if frag.style.bold %}<strong>{% endif %}
-        {% if frag.style.italic %}<em>{% endif %}
-            {% if frag.style.underline %}<u>{% endif %}
-                {{ frag.text }}
-                {% if frag.style.underline %}</u>{% endif %}
-            {% if frag.style.italic %}</em>{% endif %}
-        {% if frag.style.bold %}</strong>{% endif %}
-</a>
-{% else %}
-{% if frag.style.bold %}<strong>{% endif %}
-    {% if frag.style.italic %}<em>{% endif %}
-        {% if frag.style.underline %}<u>{% endif %}
-            {{ frag.text }}
-            {% if frag.style.underline %}</u>{% endif %}
-        {% if frag.style.italic %}</em>{% endif %}
-    {% if frag.style.bold %}</strong>{% endif %}
-{% endif %}
-{% endif %}
+{%- if frag.link_url %}<a href="{{ frag.link_url|e }}">{% endif -%}
+{%- if frag.style.bold %}<strong>{% endif -%}
+{%- if frag.style.italic %}<em>{% endif -%}
+{%- if frag.style.underline %}<u>{% endif -%}
+{{- frag.text -}}
+{%- if frag.style.underline %}</u>{% endif -%}
+{%- if frag.style.italic %}</em>{% endif -%}
+{%- if frag.style.bold %}</strong>{% endif -%}
+{%- if frag.link_url %}</a>{% endif %}
 {% endif %}
 {% endfor %}

--- a/boosty_downloader/src/infrastructure/html_generator/templates/video.html
+++ b/boosty_downloader/src/infrastructure/html_generator/templates/video.html
@@ -1,4 +1,4 @@
 <video controls>
-    <source src="{{ video.url }}" type="video/mp4">
+    <source src="{{ src }}"{% if mime_type %} type="{{ mime_type }}"{% endif %}>
     Your browser does not support the video tag.
 </video>

--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -210,6 +210,18 @@
 </li>
 </ul>
 
+
+<ol>
+        <li>
+                Step one
+
+</li>
+        <li>
+                Step two
+
+</li>
+</ol>
+
 <img src="https://example.com/banner.jpg" alt="Image" style="max-width: 100%;">
 <video controls>
     <source src="https://example.com/video.mp4" type="video/mp4">

--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -160,357 +160,54 @@
     <button id="theme-toggle" aria-label="Toggle theme">🌙</button>
 
     <div class="content">
-        
-
-
-
-<h1>Welcome to my Boosty!</h1>
-
-
-
-
-
-
-
-    
-        
+        <h1>Welcome to my Boosty!</h1>
             This post includes various elements: text, media, and lists.
-            
-        
-    
-
-
-
-
-
-
-
-
-
-    
-        
             &lt;NEW_LINE_SYMBOL&gt;
-            
-        
-    
-
-
-
-
-
-
-
-
-
-    <em>
-        
-            Let&#39;s dive in below:
-            
-        </em>
-    
-
-
-
-
-
-
-
-
+<em>            Let&#39;s dive in below:
+</em>
 <h2>Highlights</h2>
-
-
-
-
-
-
-
-    
-        
             This paragraph contains a mix of 
-            
-        
-    
-
-
-
-
-
-
-
-
-<strong>
-    
-        
-            bold
-            
-        
-    </strong>
-
-
-
-
-
-
-
-
-
-    
-        
-            , 
-            
-        
-    
-
-
-
-
-
-
-
-
-
-    <em>
-        
-            italic
-            
-        </em>
-    
-
-
-
-
-
-
-
-
-
-    
-        
-            , and 
-            
-        
-    
-
-
-
-
-
-
-
-
-
-    
-        <u>
-            underlined
-            </u>
-        
-    
-
-
-
-
-
-
-
-
-
-    
-        
-             text. You can 
-            
-        
-    
-
-
-
-
-
-
-
-
+<strong>            bold
+</strong>            , 
+<em>            italic
+</em>            , and 
+<u>            underlined
+</u>             text. You can 
 <a href="https://boosty.to/example">
-    
-        
-            <u>
-                click here
-                </u>
-            
-        
-</a>
-
-
-
-
-
-
-
-
-
-    
-        
+<u>                click here
+</u></a>
              to support me.
-            
-        
-    
-
-
-
-
-
 
 
     <ul>
-        
-        
         <li>
-    
-    
+                📌 What you&#39;ll get inside:
 
-
-
-
-
-    
-        
-            📌 What you&#39;ll get inside:
-            
-        
-    
-
-
-
-
-    
-    
-    
         <ul>
-            
-            
             <li>
-    
-    
+                High-quality images
 
-
-
-
-
-    
-        
-            High-quality images
-            
-        
-    
-
-
-
-
-    
-    
 </li>
-            
             <li>
-    
-    
+                Source files (PSD, RAW)
 
-
-
-
-
-    
-        
-            Source files (PSD, RAW)
-            
-        
-    
-
-
-
-
-    
-    
 </li>
-            
             <li>
-    
-    
+                Bonus video content
 
-
-
-
-
-    
-        
-            Bonus video content
-            
-        
-    
-
-
-
-
-    
-    
-    
         <ul>
-            
-            
             <li>
-    
-    
+                Behind the scenes
 
-
-
-
-
-    
-        
-            Behind the scenes
-            
-        
-    
-
-
-
-
-    
-    
 </li>
-            
             <li>
-    
-    
+                Unreleased footage
 
-
-
-
-
-    
-        
-            Unreleased footage
-            
-        
-    
-
-
-
-
-    
-    
 </li>
-            
-            
     </ul>
-    
-    
 </li>
-            
-            
     </ul>
-    
-    
 </li>
-        
-        
 </ul>
 
 <img src="https://example.com/banner.jpg" alt="Image" style="max-width: 100%;">
@@ -519,51 +216,16 @@
     Your browser does not support the video tag.
 </video>
 <video controls>
-    <source src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" type="video/mp4">
+    <source src="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
     Your browser does not support the video tag.
 </video>
-
-
-
-
-
-
-    
-        
             &lt;NEW_LINE_SYMBOL&gt;
-            
-        
-    
-
-
-
-
-
-
-
 <h2>Thanks for reading!</h2>
-
-
-
-
-
-
-
-    
-        
             Feel free to leave a comment or suggestion below.
-            
-        
-    
 
-
-
-
-<a href="files/release-notes.zip" download>release <v2> & notes.zip</a>
+<a href="files/release-notes.zip" download>release &lt;v2&gt; &amp; notes.zip</a>
 <div class="audio-player">
-    
     <div class="audio-title">fixture-song.mp3</div>
-    
     <audio controls>
         <source src="audio/fixture-song.mp3">
         Your browser does not support the audio tag.

--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -161,39 +161,40 @@
 
     <div class="content">
         <h1>Welcome to my Boosty!</h1>
-This post includes various elements: text, media, and lists.&lt;NEW_LINE_SYMBOL&gt;<em>Let&#39;s dive in below:</em>
+This post includes various elements: text, media, and lists.<br>
+<em>Let&#39;s dive in below:</em>
 <h2>Highlights</h2>
 This paragraph contains a mix of <strong>bold</strong>, <em>italic</em>, and <u>underlined</u> text. You can <a href="https://boosty.to/example"><u>click here</u></a> to support me.
 <ul>
     <li>
-    📌 What you&#39;ll get inside:
-    <ul>
-        <li>
-        High-quality images
-        </li>
-        <li>
-        Source files (PSD, RAW)
-        </li>
-        <li>
-        Bonus video content
+        📌 What you&#39;ll get inside:
         <ul>
             <li>
-            Behind the scenes
+                High-quality images
             </li>
             <li>
-            Unreleased footage
+                Source files (PSD, RAW)
+            </li>
+            <li>
+                Bonus video content
+                <ul>
+                    <li>
+                        Behind the scenes
+                    </li>
+                    <li>
+                        Unreleased footage
+                    </li>
+                </ul>
             </li>
         </ul>
-        </li>
-    </ul>
     </li>
 </ul>
 <ol>
     <li>
-    Step one
+        Step one
     </li>
     <li>
-    Step two
+        Step two
     </li>
 </ol>
 <img src="https://example.com/banner.jpg" alt="Image" style="max-width: 100%;">
@@ -205,7 +206,8 @@ This paragraph contains a mix of <strong>bold</strong>, <em>italic</em>, and <u>
     <source src="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
     Your browser does not support the video tag.
 </video>
-&lt;NEW_LINE_SYMBOL&gt;<h2>Thanks for reading!</h2>
+<br>
+<h2>Thanks for reading!</h2>
 Feel free to leave a comment or suggestion below.
 <a href="files/release-notes.zip" download>release &lt;v2&gt; &amp; notes.zip</a>
 <div class="audio-player">

--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -161,67 +161,41 @@
 
     <div class="content">
         <h1>Welcome to my Boosty!</h1>
-            This post includes various elements: text, media, and lists.
-            &lt;NEW_LINE_SYMBOL&gt;
-<em>            Let&#39;s dive in below:
-</em>
+This post includes various elements: text, media, and lists.&lt;NEW_LINE_SYMBOL&gt;<em>Let&#39;s dive in below:</em>
 <h2>Highlights</h2>
-            This paragraph contains a mix of 
-<strong>            bold
-</strong>            , 
-<em>            italic
-</em>            , and 
-<u>            underlined
-</u>             text. You can 
-<a href="https://boosty.to/example">
-<u>                click here
-</u></a>
-             to support me.
-
-
+This paragraph contains a mix of <strong>bold</strong>, <em>italic</em>, and <u>underlined</u> text. You can <a href="https://boosty.to/example"><u>click here</u></a> to support me.
+<ul>
+    <li>
+    📌 What you&#39;ll get inside:
     <ul>
         <li>
-                📌 What you&#39;ll get inside:
-
+        High-quality images
+        </li>
+        <li>
+        Source files (PSD, RAW)
+        </li>
+        <li>
+        Bonus video content
         <ul>
             <li>
-                High-quality images
-
-</li>
+            Behind the scenes
+            </li>
             <li>
-                Source files (PSD, RAW)
-
-</li>
-            <li>
-                Bonus video content
-
-        <ul>
-            <li>
-                Behind the scenes
-
-</li>
-            <li>
-                Unreleased footage
-
-</li>
+            Unreleased footage
+            </li>
+        </ul>
+        </li>
     </ul>
-</li>
-    </ul>
-</li>
+    </li>
 </ul>
-
-
 <ol>
-        <li>
-                Step one
-
-</li>
-        <li>
-                Step two
-
-</li>
+    <li>
+    Step one
+    </li>
+    <li>
+    Step two
+    </li>
 </ol>
-
 <img src="https://example.com/banner.jpg" alt="Image" style="max-width: 100%;">
 <video controls>
     <source src="https://example.com/video.mp4" type="video/mp4">
@@ -231,10 +205,8 @@
     <source src="https://www.youtube.com/watch?v=dQw4w9WgXcQ">
     Your browser does not support the video tag.
 </video>
-            &lt;NEW_LINE_SYMBOL&gt;
-<h2>Thanks for reading!</h2>
-            Feel free to leave a comment or suggestion below.
-
+&lt;NEW_LINE_SYMBOL&gt;<h2>Thanks for reading!</h2>
+Feel free to leave a comment or suggestion below.
 <a href="files/release-notes.zip" download>release &lt;v2&gt; &amp; notes.zip</a>
 <div class="audio-player">
     <div class="audio-title">fixture-song.mp3</div>

--- a/test/fixtures/rendered_post.html
+++ b/test/fixtures/rendered_post.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="UTF-8" />
-    <title>HTML Report</title>
+    <title>Showcase post</title>
 
     <script>
         (function () {

--- a/test/unit/html_generator/html_templates_test.py
+++ b/test/unit/html_generator/html_templates_test.py
@@ -10,6 +10,7 @@ from boosty_downloader.src.infrastructure.html_generator.models import (
     HtmlGenText,
     HtmlGenVideo,
     HtmlListItem,
+    HtmlListStyle,
     HtmlTextFragment,
     HtmlTextStyle,
 )
@@ -133,6 +134,23 @@ def _showcase_chunks() -> list[HtmlGenChunk]:
                     ],
                 )
             ]
+        ),
+        HtmlGenList(
+            style=HtmlListStyle.ORDERED,
+            items=[
+                HtmlListItem(
+                    data=[
+                        HtmlGenText(text_fragments=[HtmlTextFragment(text='Step one')])
+                    ],
+                    nested_items=[],
+                ),
+                HtmlListItem(
+                    data=[
+                        HtmlGenText(text_fragments=[HtmlTextFragment(text='Step two')])
+                    ],
+                    nested_items=[],
+                ),
+            ],
         ),
         HtmlGenImage(url='https://example.com/banner.jpg'),
         HtmlGenVideo(

--- a/test/unit/html_generator/html_templates_test.py
+++ b/test/unit/html_generator/html_templates_test.py
@@ -29,7 +29,7 @@ def _showcase_chunks() -> list[HtmlGenChunk]:
                 HtmlTextFragment(
                     text='This post includes various elements: text, media, and lists.',
                 ),
-                HtmlTextFragment(text='<NEW_LINE_SYMBOL>'),
+                HtmlTextFragment(text='\n'),
                 HtmlTextFragment(
                     text="Let's dive in below:",
                     style=HtmlTextStyle(italic=True),
@@ -160,7 +160,7 @@ def _showcase_chunks() -> list[HtmlGenChunk]:
         HtmlGenVideo(url='https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
         HtmlGenText(
             text_fragments=[
-                HtmlTextFragment(text='<NEW_LINE_SYMBOL>'),
+                HtmlTextFragment(text='\n'),
                 HtmlTextFragment(text='Thanks for reading!', header_level=2),
                 HtmlTextFragment(
                     text='Feel free to leave a comment or suggestion below.',
@@ -168,8 +168,8 @@ def _showcase_chunks() -> list[HtmlGenChunk]:
             ]
         ),
         HtmlGenFile(
-            # The markup in the name pins current renderer behavior: file links
-            # are built with a plain f-string, the name goes into HTML unescaped.
+            # Markup in the name pins the escaping: it must land in HTML
+            # as text, never as tags.
             url='files/release-notes.zip',
             filename='release <v2> & notes.zip',
         ),

--- a/test/unit/html_generator/html_templates_test.py
+++ b/test/unit/html_generator/html_templates_test.py
@@ -162,11 +162,11 @@ def _showcase_chunks() -> list[HtmlGenChunk]:
 def test_html_generator_templates(tmp_path: Path):
     chunks = _showcase_chunks()
 
-    data = render_html(chunks)
+    data = render_html(chunks, page_title='Showcase post')
 
     test_output_file = tmp_path / 'test_output.html'
 
-    render_html_to_file(chunks, test_output_file)
+    render_html_to_file(chunks, test_output_file, page_title='Showcase post')
 
     assert test_output_file.exists()
     assert test_output_file.read_text(encoding='utf-8') == data
@@ -182,7 +182,7 @@ def test_showcase_matches_the_pinned_golden_html():
     An intentional template change regenerates the file:
     UPDATE_GOLDEN=1 task test - then review the golden diff.
     """
-    html = render_html(_showcase_chunks())
+    html = render_html(_showcase_chunks(), page_title='Showcase post')
 
     if os.environ.get('UPDATE_GOLDEN') == '1':
         GOLDEN_FILE.write_text(html, encoding='utf-8')

--- a/test/unit/mappers/list_style_test.py
+++ b/test/unit/mappers/list_style_test.py
@@ -1,0 +1,55 @@
+"""Ordered lists must stay ordered on the way from the API to HTML."""
+
+from __future__ import annotations
+
+import pytest
+
+from boosty_downloader.src.application.mappers.html_converter import (
+    convert_list_to_html,
+)
+from boosty_downloader.src.application.mappers.list import to_domain_list_chunk
+from boosty_downloader.src.domain.post_data_chunks import PostDataChunkTextualList
+from boosty_downloader.src.infrastructure.boosty_api.models.post.post_data_types.post_data_list import (
+    BoostyPostDataListDTO,
+)
+from boosty_downloader.src.infrastructure.html_generator.models import HtmlListStyle
+
+ListStyle = PostDataChunkTextualList.ListStyle
+
+
+@pytest.mark.parametrize(
+    ('api_style', 'expected'),
+    [
+        ('ordered', ListStyle.ordered),
+        ('unordered', ListStyle.unordered),
+        (None, ListStyle.unordered),
+        ('checklist', ListStyle.unordered),
+    ],
+    ids=['ordered', 'unordered', 'absent', 'unknown'],
+)
+def test_api_list_style_lands_in_the_domain(api_style: str | None, expected: ListStyle):
+    """The author's numbering used to be dropped here: every list became bullets."""
+    payload: dict[str, object] = {'type': 'list', 'items': []}
+    if api_style is not None:
+        payload['style'] = api_style
+
+    chunk = to_domain_list_chunk(BoostyPostDataListDTO.model_validate(payload))
+
+    assert chunk.style is expected
+
+
+@pytest.mark.parametrize(
+    ('domain_style', 'expected'),
+    [
+        (ListStyle.ordered, HtmlListStyle.ORDERED),
+        (ListStyle.unordered, HtmlListStyle.UNORDERED),
+    ],
+    ids=['ordered', 'unordered'],
+)
+def test_domain_list_style_lands_in_html(
+    domain_style: ListStyle, expected: HtmlListStyle
+):
+    """A hardcoded UNORDERED here silently killed the numbering after mapping."""
+    chunk = PostDataChunkTextualList(items=[], style=domain_style)
+
+    assert convert_list_to_html(chunk).style is expected


### PR DESCRIPTION
# [renderer] Fix rendered post look: title, numbering, escaping, clean markup

## Summary

Six renderer problems fixed in one pass (stacked on #155, merge order: #153 -> #154 -> #155 -> this). Every fix is visible as a golden-file diff - the goldens from #155 were added for exactly this purpose.

## Problem

- post.html was ~600 lines of mostly blank lines and stray indentation: Jinja control lines leaked their whitespace, templates carried decorative indentation that broke on recursion (stair-stepped `<li>` / `</li>`)
- Every saved post showed "HTML Report" in the browser tab
- Numbered lists rendered as bullet lists: the API style was parsed but dropped on the way to HTML, the `<ol>` template branch was dead
- A file name with markup broke the page: file links were built with an f-string, bypassing autoescape
- Every video got a hardcoded `type="video/mp4"` - external downloads can be webm/mkv
- The renderer mutated chunk urls in place

## Fix

- `trim_blocks`/`lstrip_blocks` on the Jinja environment, re-flowed `text.html` and `list.html`: inline styles render as one line, nested lists indent classically (content at +4, close tags aligned), empty chunks leave no blank lines
- `render_html` takes a required `page_title`; the use case passes the post title (folder name for empty titles)
- The list style now travels the whole chain: API DTO -> domain field -> converter -> template; unknown styles fall back to bullets
- File links render through a template: names and urls are escaped
- Video MIME type comes from the file extension; unknown ones omit the attribute so the browser sniffs
- Windows path slashes are normalized in a local helper instead of mutating the chunk

## Verification

- `task ci` green: checks, 155 unit tests + 1 strict xfail, build; live integration tests 6/6 (one transient network timeout on first run, curl failed at the same moment, retry passed in 2s)
- Live download of a real post: the tab shows the post title, the content section has zero blank lines, image paths stay relative
- Golden diffs reviewed stage by stage: escaped file name, conditional MIME, live `<ol>`, clean indentation

## Notes

- Already downloaded posts keep their old HTML (the cache skips them) - the new rendering applies to new and updated posts; a full re-render belongs to the manifests design
- Changelog updated (4 entries under Fixed)
