### PR TITLE
[tests] Add local-server e2e and CLI smoke, report coverage in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,9 +44,11 @@ jobs:
       # Integration tests need Boosty API credentials stored in ./.env
       # (repo root - that's where pydantic-settings loads it from).
       # The file is gitignored, so CI and fork PRs run unit tests only.
+      # Coverage is reported, not enforced: watch the number in the log
+      # (78% on 2026-08-17).
       - name: Run tests
         run: |
-          task test -- -v
+          task test:cov -- -v
           if [ -f .env ]; then
             task test:api -- -v
           else

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -89,12 +89,12 @@ tasks:
   test:
     desc: "Run unit tests (extra pytest args after --: task test -- -v)"
     cmds:
-      - uv run pytest {{.CLI_ARGS}} test/unit/
+      - uv run pytest {{.CLI_ARGS}} test/unit/ test/e2e/
 
   test:cov:
     desc: "Run unit tests with a coverage report (uncovered lines included)"
     cmds:
-      - uv run pytest --cov --cov-report=term-missing {{.CLI_ARGS}} test/unit/
+      - uv run pytest --cov --cov-report=term-missing {{.CLI_ARGS}} test/unit/ test/e2e/
 
   test:api:
     desc: Run integration tests against the live API (requires ./.env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,9 +53,9 @@ default-groups = "all"
 [tool.pytest.ini_options]
 # auto mode: every async test runs under asyncio without a manual mark.
 asyncio_mode = "auto"
-# Bare `pytest` runs only unit tests: integration ones need live credentials.
-# An explicit path argument (task test:api) overrides this.
-testpaths = ["test/unit"]
+# Bare `pytest` runs unit and e2e (local server) tests: integration ones
+# need live credentials. An explicit path argument (task test:api) overrides this.
+testpaths = ["test/unit", "test/e2e"]
 # -ra: show the reason for every skip/xfail in the summary.
 addopts = "-ra --strict-markers"
 

--- a/test/e2e/download_flow_test.py
+++ b/test/e2e/download_flow_test.py
@@ -1,0 +1,197 @@
+"""End-to-end: a full download run against a local Boosty-shaped server.
+
+The server serves the sanitized fixture post and small media blobs. The run
+uses the real API client, file downloader, cache and renderer - only the
+console reporter and yt-dlp are absent. This is the safety net for the DI
+and use-case refactoring stages: the on-disk tree must not change.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import TestServer
+from aiohttp_retry import ExponentialRetry, RetryClient
+
+from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.filtering import (
+    BoostyOkVideoType,
+    DownloadContentTypeFilter,
+)
+from boosty_downloader.src.application.use_cases.download_all_posts import (
+    DownloadAllPostUseCase,
+)
+from boosty_downloader.src.infrastructure.boosty_api.core.client import BoostyAPIClient
+from boosty_downloader.src.infrastructure.loggers.base import RichLogger
+from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import (
+    FailedDownloadsLogger,
+)
+from boosty_downloader.src.infrastructure.post_caching.post_cache import (
+    SQLitePostCache,
+)
+
+if TYPE_CHECKING:
+    from yarl import URL
+
+    from boosty_downloader.src.cli.console_progress_reporter import ProgressReporter
+    from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+        ExternalVideosDownloader,
+    )
+
+FIXTURE_FILE = Path(__file__).parents[1] / 'fixtures' / 'single_post.json'
+AUTHOR = 'example_author'
+POST_DIR_NAME = '2025-06-15 - Fixture post with every content type (00000000)'
+
+# The committed fixture points at these fake hosts; the server rewrites them
+# to itself so every media request stays local.
+_FAKE_HOSTS = ('https://cdn.example', 'https://images.example', 'https://video.example')
+
+
+class _QuietReporter:
+    """Collects messages instead of rendering rich console output."""
+
+    def __init__(self) -> None:
+        self.notices: list[str] = []
+        self.warnings: list[str] = []
+        self.errors: list[str] = []
+
+    def create_task(self, *args: object, **kwargs: object) -> uuid.UUID:
+        del args, kwargs
+        return uuid.uuid4()
+
+    def update_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def complete_task(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    def success(self, message: str) -> None:
+        del message
+
+    def notice(self, message: str) -> None:
+        self.notices.append(message)
+
+    def warn(self, message: str) -> None:
+        self.warnings.append(message)
+
+    def error(self, message: str) -> None:
+        self.errors.append(message)
+
+
+def _build_app(served_media: list[str]) -> web.Application:
+    fixture_text = FIXTURE_FILE.read_text(encoding='utf-8')
+
+    async def listing(request: web.Request) -> web.Response:
+        local_text = fixture_text
+        for host in _FAKE_HOSTS:
+            local_text = local_text.replace(host, f'http://{request.host}')
+        return web.json_response(
+            {
+                'data': [json.loads(local_text)],
+                'extra': {'offset': '', 'isLast': True},
+            }
+        )
+
+    async def blob(request: web.Request) -> web.Response:
+        served_media.append(request.path)
+        if '/image/' in request.path:
+            return web.Response(body=b'png bytes', content_type='image/png')
+        if request.path.endswith('.mp4'):
+            return web.Response(body=b'mp4 bytes', content_type='video/mp4')
+        if '/audio/' in request.path:
+            return web.Response(body=b'mp3 bytes', content_type='audio/mpeg')
+        return web.Response(body=b'file bytes', content_type='application/octet-stream')
+
+    app = web.Application()
+    app.router.add_get(f'/v1/blog/{AUTHOR}/post/', listing)
+    app.router.add_get('/{tail:.*}', blob)
+    return app
+
+
+async def _run_download(
+    destination: Path, api_base: URL, reporter: _QuietReporter
+) -> None:
+    """One full download run wired exactly like the app, minus the console."""
+    async with ClientSession() as session:
+        retry_client = RetryClient(
+            session, retry_options=ExponentialRetry(attempts=2, start_timeout=0.1)
+        )
+        boosty_api = BoostyAPIClient(retry_client, base_url=api_base / 'v1/')
+        with SQLitePostCache(destination, RichLogger('e2e-cache')) as cache:
+            context = DownloadContext(
+                author_name=AUTHOR,
+                downloader_session=retry_client,
+                # The fixture has no external videos: yt-dlp must stay out.
+                external_videos_downloader=cast('ExternalVideosDownloader', None),
+                post_cache=cache,
+                filters=list(DownloadContentTypeFilter),
+                preferred_video_quality=BoostyOkVideoType.medium,
+                progress_reporter=cast('ProgressReporter', reporter),
+                failed_logger=FailedDownloadsLogger(
+                    destination / 'failed_downloads.log'
+                ),
+            )
+            await DownloadAllPostUseCase(
+                author_name=AUTHOR,
+                boosty_api=boosty_api,
+                destination=destination,
+                download_context=context,
+            ).execute()
+
+
+def _assert_post_tree(destination: Path) -> None:
+    """The on-disk layout is the app's public contract with its users."""
+    post_dir = destination / POST_DIR_NAME
+    tree = sorted(p.name for p in destination.iterdir())
+    assert post_dir.is_dir(), f'actual tree: {tree}'
+
+    images = sorted(p.name for p in (post_dir / 'images').iterdir())
+    assert images == ['10000000-0000-4000-8000-000000000201.png']
+    assert (post_dir / 'files' / 'fixture-archive.zip').read_bytes() == b'file bytes'
+    videos = sorted(p.name for p in (post_dir / 'boosty_videos').iterdir())
+    assert videos == ['Fixture video (10000000).mp4']
+    audio = sorted(p.name for p in (post_dir / 'audio').iterdir())
+    assert audio == ['fixture-song.mp3']
+
+    html = (post_dir / 'post.html').read_text(encoding='utf-8')
+    assert '<title>Fixture post with every content type</title>' in html
+    assert 'images/10000000-0000-4000-8000-000000000201.png' in html
+    assert 'boosty_videos/Fixture video (10000000).mp4' in html
+    assert 'audio/fixture-song.mp3' in html
+
+
+async def test_full_run_builds_the_expected_post_tree(tmp_path: Path) -> None:
+    served_media: list[str] = []
+    server = TestServer(_build_app(served_media))
+    await server.start_server()
+    try:
+        reporter = _QuietReporter()
+        await _run_download(tmp_path, server.make_url('/'), reporter)
+
+        assert reporter.errors == []
+        _assert_post_tree(tmp_path)
+    finally:
+        await server.close()
+
+
+async def test_second_run_serves_from_cache(tmp_path: Path) -> None:
+    """A rerun must not touch the network for media: that is the cache promise."""
+    served_media: list[str] = []
+    server = TestServer(_build_app(served_media))
+    await server.start_server()
+    try:
+        await _run_download(tmp_path, server.make_url('/'), _QuietReporter())
+        media_after_first = len(served_media)
+        assert media_after_first > 0
+
+        reporter = _QuietReporter()
+        await _run_download(tmp_path, server.make_url('/'), reporter)
+
+        assert len(served_media) == media_after_first
+        assert any('cached' in notice for notice in reporter.notices)
+    finally:
+        await server.close()

--- a/test/unit/cli/cli_smoke_test.py
+++ b/test/unit/cli/cli_smoke_test.py
@@ -1,0 +1,41 @@
+"""CLI smoke: the real typer app parses argv - a net for command wiring.
+
+Unlike exit_codes_test.py (which stubs the app), these run the actual
+command registration and argument parsing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typer.testing import CliRunner
+
+from boosty_downloader.main import typer_app
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    'args',
+    [
+        [],
+        ['--help'],
+        ['download', '--help'],
+        ['check', '--help'],
+        ['clean-cache', '--help'],
+        ['show-auth-script', '--help'],
+    ],
+    ids=['no-args', 'help', 'download', 'check', 'clean-cache', 'show-auth-script'],
+)
+def test_help_screens_exit_cleanly(args: list[str]) -> None:
+    """A broken command registration would crash before doing any work."""
+    result = runner.invoke(typer_app, args)
+
+    assert result.exit_code == 0, result.output
+
+
+def test_download_without_username_is_a_usage_error() -> None:
+    """Regression for 5.1: a missing --username used to crash instead of a hint."""
+    result = runner.invoke(typer_app, ['download'])
+
+    assert result.exit_code == 2
+    assert 'username' in result.output


### PR DESCRIPTION
# [tests] Add local-server e2e and CLI smoke, report coverage in CI

## Summary

Final PR of the test safety-net stage. The e2e test is the piece the audit called the key to a safe DI/use-case refactoring: a full download run must produce exactly the same tree on disk, byte for byte where it matters. No network, no credentials - everything runs against a local server, so it works in CI and forks.

## What is in here

**E2e** (`test/e2e/download_flow_test.py`):

- a local aiohttp test server plays Boosty: serves the sanitized fixture post (rewriting its fake hosts to itself) and small media blobs
- the run is wired like the real app: real `BoostyAPIClient` (pointed at the local server), real file downloader, real SQLite cache, real HTML renderer; only the console reporter and yt-dlp are absent
- test 1 asserts the on-disk contract: post folder named `date - title (id8)`, image with a guessed `.png`, file with the author's exact name and bytes, video `Fixture video (10000000).mp4`, audio, post.html with the title and relative links
- test 2 asserts the cache promise: a second run makes zero media requests and reports the post as cached

**CLI smoke** (`test/unit/cli/cli_smoke_test.py`): the real typer app through `CliRunner` - every help screen exits 0, `download` without `--username` is a usage error (exit 2), not a crash.

**Coverage in CI**: the test step runs `task test:cov`, so every CI log shows the coverage table (78% now). Reported, not enforced - a deliberate choice.

## Verification

- `task ci` checks green: lint, format, pyright, **164 passed + 1 xfail**, build
- Both e2e tests pass in ~1.5s, no external requests

## Notes

- `test/e2e` added to `testpaths` and both Taskfile test targets
- No changelog entry: tests and CI only (`ci/skip-changelog`)
- This closes the safety-net stage: client, cache, filters, mapper golden, HTML golden, e2e, smoke - all eight audit categories exist
