### PR TITLE
[downloader] Fix failure diagnostics: exit codes, tracebacks, timeout messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `--post-url` now exits with code 1 when the post is not found, not accessible or fails to download, and with 130 on Ctrl+C - previously every failure looked like a success to scripts and cron
 - A removed or restricted external video no longer crashes the run with a raw traceback - it is reported and written to failed_downloads.log like any other failed download
+- A network timeout in the middle of a download is now reported as "Download timed out: the server stopped sending data" instead of the misleading "Failed during I/O operation" that pointed at the disk
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 - `--post-url` now exits with code 1 when the post is not found, not accessible or fails to download, and with 130 on Ctrl+C - previously every failure looked like a success to scripts and cron
+- A removed or restricted external video no longer crashes the run with a raw traceback - it is reported and written to failed_downloads.log like any other failed download
 
 ## 3.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+### Fixed
+
+- `--post-url` now exits with code 1 when the post is not found, not accessible or fails to download, and with 130 on Ctrl+C - previously every failure looked like a success to scripts and cron
+
 ## 3.5.0
 
 ### Fixed

--- a/boosty_downloader/src/application/use_cases/download_single_post.py
+++ b/boosty_downloader/src/application/use_cases/download_single_post.py
@@ -45,7 +45,7 @@ from boosty_downloader.src.domain.post_data_chunks import (
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
     ExternalVideoDownloadStatus,
-    ExtVideoDownloadError,
+    ExtVideoError,
     ExtVideoInfoError,
     ExtVideoInterruptedByUserError,
 )
@@ -306,15 +306,18 @@ class DownloadSinglePostUseCase:
                 message='External video unavailable or access restricted.',
                 resource='UNAVAILABLE',
             ) from e
-        except ExtVideoDownloadError as e:
+        # The base class catches every present and future family member:
+        # a raw yt-dlp failure must never escape as a traceback.
+        except ExtVideoError as e:
+            resource = e.video_url or 'unknown video url'
             await self.context.failed_logger.add_error(
-                f'{_form_post_url(username=self.context.author_name, post_id=post.uuid)} - {e.video_url}',
+                f'{_form_post_url(username=self.context.author_name, post_id=post.uuid)} - {resource}',
                 'External video download failed',
             )
             raise ApplicationFailedDownloadError(
                 post_uuid=post.uuid,
                 message="Couldn't download external video",
-                resource=e.video_url,
+                resource=resource,
             ) from e
 
     async def _process_chunk(  # noqa: C901, PLR0911

--- a/boosty_downloader/src/application/use_cases/download_specific_post.py
+++ b/boosty_downloader/src/application/use_cases/download_specific_post.py
@@ -1,13 +1,10 @@
 """Use case for downloading a specific Boosty post by URL."""
 
-from enum import Enum, auto
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from boosty_downloader.src.application.di.download_context import DownloadContext
-from boosty_downloader.src.application.exceptions.application_errors import (
-    ApplicationCancelledError,
-)
+from boosty_downloader.src.application.post_retry import PostOutcome
 from boosty_downloader.src.application.use_cases.check_total_posts import (
     BoostyAPIClient,
 )
@@ -40,14 +37,6 @@ if TYPE_CHECKING:
     from boosty_downloader.src.infrastructure.boosty_api.models.post.post import (
         PostDTO,
     )
-
-
-class _PostDownloadOutcome(Enum):
-    """Outcome of downloading the found post."""
-
-    downloaded = auto()
-    failed = auto()
-    cancelled = auto()
 
 
 class DownloadPostByUrlUseCase:
@@ -94,13 +83,14 @@ class DownloadPostByUrlUseCase:
         else:
             return author, post_uuid
 
-    async def execute(self) -> None:
+    async def execute(self) -> PostOutcome:
+        """Find and download the post; the caller turns the outcome into an exit code."""
         author_name, post_uuid = self.extract_author_and_uuid_from_url()
         if not author_name or not post_uuid:
             self.context.progress_reporter.error(
                 'Failed to extract author and UUID from the provided URL, aborting...'
             )
-            return
+            return PostOutcome.failed
 
         self.context.progress_reporter.info(
             f'Requesting the post with UUID: {post_uuid}...'
@@ -111,7 +101,7 @@ class DownloadPostByUrlUseCase:
             self.context.progress_reporter.error(
                 'Failed to find and download the specified post.'
             )
-            return
+            return PostOutcome.failed
         except BoostyAPIValidationError as e:
             # The searched post exists but this client can't parse it -
             # a misleading "not found" would hide the real problem.
@@ -124,17 +114,17 @@ class DownloadPostByUrlUseCase:
                 f'Please report this at {GITHUB_ISSUES_URL} '
                 'so the client can be updated.'
             )
-            return
+            return PostOutcome.failed
 
         if not post.has_access:
             self.context.progress_reporter.error(
                 f'Skip post (no access to content): {post.title}'
             )
-            return
+            return PostOutcome.failed
 
-        await self._download_post(post)
+        return await self._download_post(post)
 
-    async def _download_post(self, post: 'PostDTO') -> _PostDownloadOutcome:
+    async def _download_post(self, post: 'PostDTO') -> PostOutcome:
         """Download the found post and name how it went."""
         self.context.progress_reporter.success(
             f'Found post with UUID: {post.id}, starting download...'
@@ -152,13 +142,10 @@ class DownloadPostByUrlUseCase:
                 destination=self.destination / post_name,
                 download_context=self.context,
             ).execute()
-        except ApplicationCancelledError:
-            self.context.progress_reporter.warn('Download cancelled by user. Bye!')
-            return _PostDownloadOutcome.cancelled
         except ApplicationFailedDownloadError as e:
             hint = f' Hint: {PATH_TOO_LONG_HINT}.' if is_path_too_long_error(e) else ''
             self.context.progress_reporter.error(
                 f'Failed to download post: {e.message}, RESOURCE: ({e.resource}){hint}'
             )
-            return _PostDownloadOutcome.failed
-        return _PostDownloadOutcome.downloaded
+            return PostOutcome.failed
+        return PostOutcome.downloaded

--- a/boosty_downloader/src/cli/commands/download.py
+++ b/boosty_downloader/src/cli/commands/download.py
@@ -6,12 +6,15 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING
 
+import typer
+
 from boosty_downloader.src.application.di.download_context import DownloadContext
 from boosty_downloader.src.application.di.initialized_app import initialized_app
 from boosty_downloader.src.application.filtering import (
     DownloadContentTypeFilter,
     VideoQualityOption,
 )
+from boosty_downloader.src.application.post_retry import PostOutcome
 from boosty_downloader.src.application.use_cases.download_all_posts import (
     DownloadAllPostUseCase,
 )
@@ -37,8 +40,6 @@ from boosty_downloader.src.infrastructure.loggers.failed_downloads_logger import
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import typer
 
     from boosty_downloader.src.cli.console_progress_reporter import (
         ProgressReporter,
@@ -102,12 +103,15 @@ async def _download_handler(  # noqa: PLR0913
         )
 
         if post_url is not None:
-            await DownloadPostByUrlUseCase(
+            outcome = await DownloadPostByUrlUseCase(
                 post_url=post_url,
                 boosty_api=app_env.boosty_api_client,
                 destination=app_env.destination_directory,
                 download_context=downloading_context,
             ).execute()
+            if outcome is PostOutcome.failed:
+                # Scripts rely on the exit code: a failed download is not a success.
+                raise typer.Exit(1)
             return
 
         _show_start_summary(

--- a/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
+++ b/boosty_downloader/src/infrastructure/external_videos_downloader/external_videos_downloader.py
@@ -28,19 +28,17 @@ ExternalVideoDownloadProgressHook = Callable[['ExternalVideoDownloadStatus'], No
 class ExtVideoError(Exception):
     """Base class for external video download errors."""
 
+    def __init__(self, url: str | None = None) -> None:
+        super().__init__(url or '')
+        self.video_url = url
+
 
 class ExtVideoInfoError(ExtVideoError):
     """Raised when video information (e.g., title) cannot be extracted."""
 
-    def __init__(self, url: str) -> None:
-        self.video_url = url
-
 
 class ExtVideoDownloadError(ExtVideoError):
     """Raised when the video download fails."""
-
-    def __init__(self, url: str) -> None:
-        self.video_url = url
 
 
 class ExtVideoInterruptedByUserError(ExtVideoError):
@@ -140,7 +138,7 @@ class ExternalVideosDownloader:
                 raise ExtVideoDownloadError(url)
 
         except DownloadError as e:
-            raise ExtVideoError(url) from e
+            raise ExtVideoDownloadError(url) from e
 
         if state.final_filename is not None:
             return state.final_filename

--- a/boosty_downloader/src/infrastructure/file_downloader.py
+++ b/boosty_downloader/src/infrastructure/file_downloader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import http
 import mimetypes
 from asyncio import CancelledError
+from asyncio import TimeoutError as AsyncioTimeoutError
 from dataclasses import dataclass
 from pathlib import PurePath
 from typing import TYPE_CHECKING
@@ -81,7 +82,7 @@ class DownloadTimeoutError(DownloadError):
 
     def __init__(self, resource_url: str, file: Path | None = None) -> None:
         super().__init__(
-            'Download timed out for the destination server',
+            'Download timed out: the server stopped sending data',
             file,
             resource_url=resource_url,
         )
@@ -205,7 +206,10 @@ async def download_file(
                 raise DownloadCancelledError(
                     file=file_path, resource_url=dl_config.url
                 ) from e
-            except DownloadTimeoutError as e:
+            # Must precede the connection branch: aiohttp's read-timeout
+            # errors inherit from both families, and "the server went
+            # quiet" is the diagnosis the user can act on.
+            except (TimeoutError, AsyncioTimeoutError) as e:
                 raise DownloadTimeoutError(
                     file=file_path, resource_url=dl_config.url
                 ) from e

--- a/test/unit/file_downloader/timeout_diagnosis_test.py
+++ b/test/unit/file_downloader/timeout_diagnosis_test.py
@@ -1,0 +1,106 @@
+"""A network timeout must be diagnosed as a timeout, not as a disk failure."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, cast
+
+import pytest
+from aiohttp import SocketTimeoutError
+
+from boosty_downloader.src.infrastructure.file_downloader import (
+    DownloadConnectionError,
+    DownloadFileConfig,
+    DownloadTimeoutError,
+    download_file,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+    from aiohttp_retry import RetryClient
+
+URL = 'https://cdn.example/file'
+
+
+class _FakeContent:
+    """Streams one chunk, then raises the prepared error."""
+
+    def __init__(self, error: BaseException) -> None:
+        self._error = error
+
+    def iter_chunked(self, size: int) -> AsyncIterator[bytes]:
+        del size
+
+        async def _stream() -> AsyncIterator[bytes]:
+            yield b'first chunk'
+            raise self._error
+
+        return _stream()
+
+
+class _FakeResponse:
+    status = 200
+    reason = 'OK'
+    content_length = None
+
+    def __init__(self, error: BaseException) -> None:
+        self.content = _FakeContent(error)
+
+
+class _FakeRequestContext:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self._response
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    def get(self, url: str) -> _FakeRequestContext:
+        del url
+        return _FakeRequestContext(self._response)
+
+
+def _config(error: BaseException, destination: Path) -> DownloadFileConfig:
+    return DownloadFileConfig(
+        session=cast('RetryClient', _FakeSession(_FakeResponse(error))),
+        url=URL,
+        filename='clip.mp4',
+        destination=destination,
+        guess_extension=False,
+    )
+
+
+@pytest.mark.parametrize(
+    'error',
+    [TimeoutError('read timed out'), asyncio.TimeoutError(), SocketTimeoutError()],
+    ids=['builtin', 'asyncio', 'aiohttp-sock-read'],
+)
+async def test_mid_download_timeout_is_reported_as_a_timeout(
+    tmp_path: Path, error: BaseException
+) -> None:
+    """The bug: a sock_read timeout surfaced as 'Failed during I/O operation',
+    sending the user to check their disk instead of their network.
+    """
+    with pytest.raises(DownloadTimeoutError) as exc_info:
+        await download_file(_config(error, tmp_path))
+
+    assert 'timed out' in exc_info.value.message
+    assert exc_info.value.resource_url == URL
+    assert exc_info.value.file is not None, 'the partial file must be reported'
+
+
+async def test_connection_reset_still_maps_to_connection_error(
+    tmp_path: Path,
+) -> None:
+    """The new timeout branch must not swallow genuine connection failures."""
+    with pytest.raises(DownloadConnectionError):
+        await download_file(_config(ConnectionResetError(), tmp_path))

--- a/test/unit/use_cases/download_specific_post_test.py
+++ b/test/unit/use_cases/download_specific_post_test.py
@@ -7,8 +7,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+import pytest
+
 from boosty_downloader.src.application.di.download_context import DownloadContext
+from boosty_downloader.src.application.exceptions.application_errors import (
+    ApplicationCancelledError,
+    ApplicationFailedDownloadError,
+)
 from boosty_downloader.src.application.filtering import BoostyOkVideoType
+from boosty_downloader.src.application.post_retry import PostOutcome
 from boosty_downloader.src.application.use_cases.download_single_post import (
     DownloadSinglePostUseCase,
 )
@@ -22,7 +29,6 @@ from boosty_downloader.src.infrastructure.boosty_api.core.client import (
 from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
 
 if TYPE_CHECKING:
-    import pytest
     from aiohttp_retry import RetryClient
 
     from boosty_downloader.src.cli.console_progress_reporter import ProgressReporter
@@ -143,11 +149,12 @@ async def test_post_downloads_via_one_direct_request(
     api = _FakeApi(post=_post())
     calls = _script_download(monkeypatch)
 
-    await _use_case(api, reporter).execute()
+    outcome = await _use_case(api, reporter).execute()
 
     assert api.requests == [('author', POST_UUID)]
     assert calls == [POST_UUID]
     assert reporter.errors == []
+    assert outcome is PostOutcome.downloaded
 
 
 async def test_missing_post_reports_not_found(
@@ -157,10 +164,11 @@ async def test_missing_post_reports_not_found(
     api = _FakeApi(error=BoostyAPINoPostError('author', POST_UUID))
     calls = _script_download(monkeypatch)
 
-    await _use_case(api, reporter).execute()
+    outcome = await _use_case(api, reporter).execute()
 
     assert calls == []
     assert any('Failed to find' in message for message in reporter.errors)
+    assert outcome is PostOutcome.failed, 'a script must see the failure in $?'
 
 
 async def test_unparsable_post_asks_to_report(
@@ -171,10 +179,11 @@ async def test_unparsable_post_asks_to_report(
     api = _FakeApi(error=BoostyAPIValidationError(errors=[]))
     calls = _script_download(monkeypatch)
 
-    await _use_case(api, reporter).execute()
+    outcome = await _use_case(api, reporter).execute()
 
     assert calls == []
     assert any('Please report this' in message for message in reporter.errors)
+    assert outcome is PostOutcome.failed
 
 
 async def test_no_access_post_is_not_downloaded(
@@ -185,7 +194,49 @@ async def test_no_access_post_is_not_downloaded(
     api = _FakeApi(post=_post(has_access=False))
     calls = _script_download(monkeypatch)
 
-    await _use_case(api, reporter).execute()
+    outcome = await _use_case(api, reporter).execute()
 
     assert calls == []
     assert any('no access' in message for message in reporter.errors)
+    assert outcome is PostOutcome.failed
+
+
+def _script_download_error(
+    monkeypatch: pytest.MonkeyPatch, error: BaseException
+) -> None:
+    async def failing_execute(self: DownloadSinglePostUseCase) -> None:
+        del self
+        raise error
+
+    monkeypatch.setattr(DownloadSinglePostUseCase, 'execute', failing_execute)
+
+
+async def test_failed_download_is_a_failed_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bug: a dead link during --post-url still ended the process with exit 0."""
+    reporter = _FakeReporter()
+    api = _FakeApi(post=_post())
+    _script_download_error(
+        monkeypatch,
+        ApplicationFailedDownloadError(
+            post_uuid=POST_UUID, message='dead link', resource='r'
+        ),
+    )
+
+    outcome = await _use_case(api, reporter).execute()
+
+    assert outcome is PostOutcome.failed
+    assert any('Failed to download post' in message for message in reporter.errors)
+
+
+async def test_cancellation_propagates_for_the_130_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Swallowing Ctrl+C here reported an interrupted run as a success."""
+    reporter = _FakeReporter()
+    api = _FakeApi(post=_post())
+    _script_download_error(monkeypatch, ApplicationCancelledError(post_uuid=POST_UUID))
+
+    with pytest.raises(ApplicationCancelledError):
+        await _use_case(api, reporter).execute()

--- a/test/unit/use_cases/ext_video_errors_test.py
+++ b/test/unit/use_cases/ext_video_errors_test.py
@@ -1,0 +1,97 @@
+"""A failed external video must become an application error, never a traceback."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from boosty_downloader.src.application.exceptions.application_errors import (
+    ApplicationFailedDownloadError,
+)
+from boosty_downloader.src.application.filtering import DownloadContentTypeFilter
+from boosty_downloader.src.application.use_cases.download_single_post import (
+    DownloadSinglePostUseCase,
+)
+from boosty_downloader.src.domain.post import Post
+from boosty_downloader.src.domain.post_data_chunks import PostDataChunkExternalVideo
+from boosty_downloader.src.infrastructure.external_videos_downloader.external_videos_downloader import (
+    ExtVideoDownloadError,
+    ExtVideoError,
+    ExtVideoInfoError,
+)
+
+if TYPE_CHECKING:
+    from boosty_downloader.src.application.di.download_context import DownloadContext
+    from boosty_downloader.src.infrastructure.boosty_api.models.post.post import PostDTO
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+class _FakeFailedLogger:
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, str]] = []
+
+    async def add_error(self, error_id: str, message: str) -> None:
+        self.entries.append((error_id, message))
+
+
+class _Context:
+    """Only the fields the error-translation path touches."""
+
+    def __init__(self) -> None:
+        self.author_name = 'author'
+        self.failed_logger = _FakeFailedLogger()
+
+
+def _post() -> Post:
+    return Post(
+        uuid='p1',
+        title='post',
+        created_at=NOW,
+        updated_at=NOW,
+        has_access=True,
+        signed_query='',
+        post_data_chunks=[],
+    )
+
+
+@pytest.mark.parametrize(
+    'error',
+    [
+        ExtVideoError('https://youtube/watch'),
+        ExtVideoError(),
+        ExtVideoDownloadError('https://youtube/watch'),
+        ExtVideoInfoError('https://youtube/watch'),
+    ],
+    ids=['base', 'base-without-url', 'download', 'info'],
+)
+async def test_every_ext_video_error_becomes_an_application_error(
+    monkeypatch: pytest.MonkeyPatch, error: ExtVideoError
+) -> None:
+    """The wrapper used to raise the bare base class past the translation tower:
+    a removed or restricted video crashed --post-url with a raw traceback.
+    """
+    context = _Context()
+    use_case = DownloadSinglePostUseCase(
+        destination=Path('unused'),
+        post_dto=cast('PostDTO', None),
+        download_context=cast('DownloadContext', context),
+    )
+
+    async def failing_download(**kwargs: object) -> Path:
+        del kwargs
+        raise error
+
+    monkeypatch.setattr(use_case, 'download_external_videos', failing_download)
+
+    with pytest.raises(ApplicationFailedDownloadError):
+        await use_case._safely_process_chunk(
+            PostDataChunkExternalVideo(url='https://youtube/watch'),
+            [DownloadContentTypeFilter.external_videos],
+            _post(),
+        )
+
+    assert context.failed_logger.entries, 'the failure must land in the failed log'


### PR DESCRIPTION
# [downloader] Fix failure diagnostics: exit codes, tracebacks, timeout messages

## Summary

Three user-facing bugs found by the architecture research sweep, fixed in one PR - all three are about the same theme: when something fails, the app must say so honestly.

## Problems and fixes

**1. `--post-url` reported every failure as success.** `boosty-downloader download -p <url> && echo ok` printed `ok` on a dead link, a missing post, a paywalled post - and even on Ctrl+C. The use case computed an outcome and threw it away. Now the outcome reaches the CLI: failures exit with code 1, Ctrl+C propagates to the top-level handler and exits 130, same as bulk runs. The private duplicated outcome enum is gone - both paths share `PostOutcome`.

**2. A removed or restricted external video crashed the run with a raw traceback.** The yt-dlp wrapper raised the bare `ExtVideoError` base class, but the error translation caught only its subclasses - the most common failure (video deleted, geo-blocked) flew past the whole error model. The raise site now uses the specific `ExtVideoDownloadError`, the translation catches the base as a safety net for future kinds, and the base class carries `video_url` so the failed log always names the video.

**3. A network timeout mid-download was reported as "Failed during I/O operation".** The timeout branch was dead code - it caught an exception nothing raises - so a `sock_read` timeout fell into the disk-failure diagnosis and sent users checking their drive instead of their network. Real timeouts (including aiohttp's `SocketTimeoutError`, which inherits from both the timeout and connection families) now map to "Download timed out: the server stopped sending data", placed before the connection branch so the right family wins.

## Verification

- `task ci` green: checks, **174 unit tests + 1 strict xfail** (10 new tests across the three fixes), e2e, build
- New tests pin each bug's story: exit-0-on-failure, the bare base class escaping translation (4 variants), all three timeout classes plus a control that connection errors still map correctly
- Changelog updated (3 entries under Fixed)
