### PR TITLE
[build] Finish the PEP 621 move: hatchling backend, clean metadata, guarded sdist

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,13 @@ jobs:
           task build
           ls dist/*.whl dist/*.tar.gz || { echo "❌ Build artifacts missing"; exit 1; }
           echo "✅ Build artifacts created successfully"
+      # The renderer loads its Jinja templates from the installed package:
+      # a wheel without them builds fine and crashes at render time.
+      - name: Verify templates are inside the wheel
+        run: |
+          TEMPLATES=$(unzip -l dist/*.whl | grep -c 'html_generator/templates/.*\.html' || true)
+          echo "Templates found in wheel: $TEMPLATES"
+          [ "$TEMPLATES" -ge 7 ] || { echo "❌ Jinja templates missing from the wheel"; exit 1; }
 
   changelog:
     name: 📝 Changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "Download any type of content from boosty.to"
 authors = [{ name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" }]
 requires-python = ">=3.10,<4"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
@@ -28,15 +30,29 @@ dependencies = [
     "aiolimiter (>=1.2.1,<2.0.0)",
     "packaging (>=25.0,<26.0)",
     "pyperclip (>=1.9.0,<2.0.0)",
-    "pyyaml>=6.0,<7.0",
+    "pyyaml (>=6.0,<7.0)",
 ]
+
+[project.urls]
+Homepage = "https://github.com/Glitchy-Sheep/boosty-downloader"
+Issues = "https://github.com/Glitchy-Sheep/boosty-downloader/issues"
+Changelog = "https://github.com/Glitchy-Sheep/boosty-downloader/blob/main/CHANGELOG.md"
 
 [project.scripts]
 boosty-downloader = "boosty_downloader.main:entry_point"
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["hatchling>=1.27,<2"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["boosty_downloader"]
+
+# Explicit allowlist: by default hatchling packs every non-vcs-ignored file
+# into the sdist, including untracked local notes. Only the package ships;
+# pyproject.toml, README and LICENSE are added automatically.
+[tool.hatch.build.targets.sdist]
+only-include = ["boosty_downloader"]
 
 [dependency-groups]
 dev = [
@@ -65,8 +81,3 @@ source = ["boosty_downloader"]
 [tool.coverage.report]
 show_missing = true
 skip_covered = true
-
-# poetry-core stays as the build backend: uv build drives it through PEP 517,
-# and the packaging output stays identical to the pre-migration wheels.
-[tool.poetry]
-packages = [{ include = "boosty_downloader" }]


### PR DESCRIPTION
# [build] Finish the PEP 621 move: hatchling backend, clean metadata, guarded sdist

## Summary

Third cleanup PR (audit этап 2). The build backend moves from poetry-core to hatchling, the metadata gets its missing fields, and the sdist becomes an explicit allowlist - which turned out to matter much more than expected.

## The important catch

hatchling's sdist default packs **every non-vcs-ignored file** into the archive - including untracked local notes. A trial build pulled 15 private working files (analysis notes, PR drafts) and a megabyte of README assets into the tarball that `task release` would have uploaded to PyPI. The sdist is now `only-include = ["boosty_downloader"]`: 2.1 MB -> 63 KB, zero private files (verified by listing the archive).

## Changes

- `[build-system]`: hatchling replaces poetry-core - the last `[tool.poetry]` key duplicated what any backend infers from the project name
- `license = "MIT"` + `license-files`, `[project.urls]` (Homepage / Issues / Changelog) - the wheel finally carries the license and links
- `pyyaml` dependency spelled in the same style as the other fourteen
- CI build job now verifies all 7 Jinja templates land in the wheel: a wheel without them builds silently and crashes at render time

## Verification

- `task build`: wheel 101 KB (7/7 templates inside), sdist 63 KB (package + README/LICENSE/pyproject only)
- Clean-venv install of the wheel: `boosty-downloader --version` -> 3.5.0; a render through the installed package proves templates load from the wheel
- The release tooling's version regexes are safe: the hatch config adds no second `version =` line
- `task check` + `task test` green: 174 passed + 1 xfail
- Live `task test:api` is currently blocked by the known network condition (curl reaches the API in 0.16s, aiohttp TLS gets cut - the anti-bot pattern, heals with a pause); the change touches no runtime code
- No changelog entry: packaging only (`ci/skip-changelog`)
