### PR TITLE
[security] Keep the account token off media downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Security
+
+- The account token and cookies no longer travel with media downloads: they went to every CDN and third-party video host with each downloaded file, though only the Boosty API needs them. Downloads now use a separate credential-free connection - access to protected media comes from the signed link itself
+- Images and audio now carry the same signed access query as files, so protected media downloads do not depend on session cookies
+
 ### Fixed
 
 - `--post-url` now exits with code 1 when the post is not found, not accessible or fails to download, and with 130 on Ctrl+C - previously every failure looked like a success to scripts and cron

--- a/boosty_downloader/application/di/app_environment.py
+++ b/boosty_downloader/application/di/app_environment.py
@@ -65,18 +65,35 @@ class AppEnvironment:
         self._exit_stack = AsyncExitStack()
         await self._exit_stack.__aenter__()
 
+        # No limit on the whole download: big videos legally take hours.
+        # Limits are on silence only - a dead connection must surface as an
+        # error, not as an eternal hang:
+        # - connect: a healthy server answers in under a second
+        # - sock_read: max quiet time between received chunks
+        network_timeout = aiohttp.ClientTimeout(total=None, connect=30, sock_read=90)
+
         authorized_boosty_session = await self._exit_stack.enter_async_context(
-            # Don't: set BASE_URL here, the BoostyAPIClient will handle it internally.
-            # Why: this session will be used for both downloading and API requests with different bases.
+            # Credentials live ONLY here: this session talks to the Boosty API.
             aiohttp.ClientSession(
                 headers=self.boosty_headers,
                 cookie_jar=self.boosty_cookies_jar,
-                # No limit on the whole download: big videos legally take
-                # hours. Limits are on silence only - a dead connection must
-                # surface as an error, not as an eternal hang:
-                # - connect: a healthy server answers in under a second
-                # - sock_read: max quiet time between received chunks
-                timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=90),
+                timeout=network_timeout,
+                trust_env=True,
+                trace_configs=[
+                    create_request_trace_config(
+                        total_attempts=self.retry_options.attempts
+                    )
+                ],
+            )
+        )
+
+        download_session = await self._exit_stack.enter_async_context(
+            # Media downloads carry no credentials: access to protected files
+            # comes from the signed query inside the url. The account token
+            # must not travel to CDN and third-party video hosts.
+            aiohttp.ClientSession(
+                cookie_jar=aiohttp.DummyCookieJar(),
+                timeout=network_timeout,
                 trust_env=True,
                 trace_configs=[
                     create_request_trace_config(
@@ -98,6 +115,9 @@ class AppEnvironment:
         authorized_retry_client = RetryClient(
             authorized_boosty_session, retry_options=self.retry_options
         )
+        downloading_retry_client = RetryClient(
+            download_session, retry_options=self.retry_options
+        )
 
         boosty_api_client = BoostyAPIClient(
             authorized_retry_client,
@@ -113,7 +133,7 @@ class AppEnvironment:
 
         return self.Environment(
             boosty_api_client=boosty_api_client,
-            downloading_retry_client=authorized_retry_client,
+            downloading_retry_client=downloading_retry_client,
             progress_reporter=progress_reporter,
             destination_directory=self.target_directory / self.author_name,
             post_cache=post_cache,

--- a/boosty_downloader/application/mappers/audio.py
+++ b/boosty_downloader/application/mappers/audio.py
@@ -7,10 +7,10 @@ from boosty_downloader.infrastructure.boosty_api.models.post.post_data_types imp
 
 
 def to_domain_audio_chunk(
-    api_audio: BoostyPostDataAudioDTO,
+    api_audio: BoostyPostDataAudioDTO, signed_query: str
 ) -> PostDataChunkAudio:
     """Convert API PostDataAudio to domain PostDataChunkAudio."""
     return PostDataChunkAudio(
-        url=api_audio.url,
+        url=api_audio.url + signed_query,
         title=api_audio.title,
     )

--- a/boosty_downloader/application/mappers/image.py
+++ b/boosty_downloader/application/mappers/image.py
@@ -6,8 +6,10 @@ from boosty_downloader.infrastructure.boosty_api.models.post.base_post_data impo
 )
 
 
-def to_domain_image_chunk(api_image: BoostyPostDataImageDTO) -> PostDataChunkImage:
+def to_domain_image_chunk(
+    api_image: BoostyPostDataImageDTO, signed_query: str
+) -> PostDataChunkImage:
     """Convert API PostDataImage to domain PostDataChunkImage."""
     return PostDataChunkImage(
-        url=api_image.url,
+        url=api_image.url + signed_query,
     )

--- a/boosty_downloader/application/mappers/post_mapper.py
+++ b/boosty_downloader/application/mappers/post_mapper.py
@@ -66,7 +66,9 @@ def map_post_dto_to_domain(  # noqa: C901, PLR0912 - one match-dispatcher over e
     for data_chunk in post_dto.data:
         match data_chunk:
             case BoostyPostDataImageDTO():
-                post.post_data_chunks.append(mappers.to_domain_image_chunk(data_chunk))
+                post.post_data_chunks.append(
+                    mappers.to_domain_image_chunk(data_chunk, post.signed_query)
+                )
             case (
                 BoostyPostDataHeaderDTO()
                 | BoostyPostDataLinkDTO()
@@ -106,7 +108,9 @@ def map_post_dto_to_domain(  # noqa: C901, PLR0912 - one match-dispatcher over e
                 if not data_chunk.complete:
                     incomplete_content_types.add(DownloadContentTypeFilter.audio)
                     continue
-                post.post_data_chunks.append(mappers.to_domain_audio_chunk(data_chunk))
+                post.post_data_chunks.append(
+                    mappers.to_domain_audio_chunk(data_chunk, post.signed_query)
+                )
             case BoostyPostDataUnknownDTO():
                 # Reported by collect_unknown_content; nothing to map here.
                 pass

--- a/test/e2e/credentials_scope_test.py
+++ b/test/e2e/credentials_scope_test.py
@@ -1,0 +1,65 @@
+"""The account token travels only to the API, never to media hosts.
+
+Built through the real AppEnvironment wiring: a local server records the
+headers each session actually sends.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import aiohttp
+from aiohttp import web
+from aiohttp.test_utils import TestServer
+from aiohttp_retry import ExponentialRetry
+from yarl import URL
+
+from boosty_downloader.application.di.app_environment import AppEnvironment
+from boosty_downloader.infrastructure.loggers.base import RichLogger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TOKEN = 'Bearer test-token'  # noqa: S105 - a fake for header assertions
+
+
+async def test_only_the_api_session_carries_credentials(tmp_path: Path) -> None:
+    """The bug: one shared session sent the account token to every media host."""
+    seen: dict[str, dict[str, str | None]] = {}
+
+    async def handler(request: web.Request) -> web.Response:
+        seen[request.path] = {
+            'auth': request.headers.get('Authorization'),
+            'cookie': request.headers.get('Cookie'),
+        }
+        return web.json_response({})
+
+    app = web.Application()
+    app.router.add_get('/{tail:.*}', handler)
+    server = TestServer(app)
+    await server.start_server()
+    try:
+        # unsafe=True: the test server lives on a bare IP, and the stdlib
+        # jar refuses to store cookies for IPs otherwise.
+        jar = aiohttp.CookieJar(unsafe=True)
+        jar.update_cookies({'session': 'secret'}, URL(str(server.make_url('/'))))
+
+        config = AppEnvironment.AppConfig(
+            author_name='author',
+            target_directory=tmp_path,
+            boosty_headers={'Authorization': TOKEN},
+            boosty_cookies_jar=jar,
+            retry_options=ExponentialRetry(attempts=1),
+            request_delay_seconds=0,
+            logger=RichLogger('credentials-scope-test'),
+        )
+        async with AppEnvironment(config) as env:
+            await env.boosty_api_client.session.get(server.make_url('/api'))
+            await env.downloading_retry_client.get(server.make_url('/media'))
+
+        assert seen['/api']['auth'] == TOKEN
+        assert seen['/api']['cookie'] == 'session=secret'
+        assert seen['/media']['auth'] is None, 'the token leaked to a media host'
+        assert seen['/media']['cookie'] is None, 'cookies leaked to a media host'
+    finally:
+        await server.close()

--- a/test/fixtures/single_post_domain.json
+++ b/test/fixtures/single_post_domain.json
@@ -67,7 +67,7 @@
         ]
       },
       {
-        "url": "https://images.example/image/10000000-0000-4000-8000-000000000201"
+        "url": "https://images.example/image/10000000-0000-4000-8000-000000000201?fake-signed-query"
       },
       {
         "filename": "fixture-archive.zip",
@@ -81,7 +81,7 @@
       },
       {
         "title": "fixture-song.mp3",
-        "url": "https://cdn.example/audio/10000000-0000-4000-8000-000000000500"
+        "url": "https://cdn.example/audio/10000000-0000-4000-8000-000000000500?fake-signed-query"
       }
     ],
     "signed_query": "?fake-signed-query",

--- a/test/unit/mappers/post_mapper_test.py
+++ b/test/unit/mappers/post_mapper_test.py
@@ -8,6 +8,9 @@ from boosty_downloader.application.mappers.post_mapper import (
     PostMappingResult,
     map_post_dto_to_domain,
 )
+from boosty_downloader.infrastructure.boosty_api.models.post.base_post_data import (
+    BoostyPostDataImageDTO,
+)
 from boosty_downloader.infrastructure.boosty_api.models.post.post import PostDTO
 from boosty_downloader.infrastructure.boosty_api.models.unknown_content import (
     UnknownContent,
@@ -294,3 +297,26 @@ def test_non_text_list_item_is_reported_not_silent():
     assert collect_unknown_content(post_dto) == {
         UnknownContent(path='data[0].items[1].items[0].data[0].type', raw='image')
     }
+
+
+def test_image_and_audio_urls_carry_the_signed_query():
+    """Only files got the access signature: protected images and audio hit 403."""
+    image = BoostyPostDataImageDTO.model_validate(
+        {
+            'type': 'image',
+            'id': 'im-1',
+            'url': 'https://cdn/img',
+            'width': 1,
+            'height': 1,
+            'size': 1,
+        }
+    )
+
+    result = map_post_dto_to_domain(
+        _make_post_dto([image, _make_audio(complete=True)]),
+        preferred_video_quality=BoostyOkVideoType.medium,
+    )
+
+    urls = [chunk.url for chunk in result.post.post_data_chunks]
+    assert urls, 'both chunks must map'
+    assert all(url.endswith('sig=abc') for url in urls), urls


### PR DESCRIPTION
# [security] Keep the account token off media downloads

## Summary

One shared aiohttp session carried the Boosty `Authorization` header and cookies on **every** request - including media downloads from CDN and third-party video hosts (OK.ru). Only the API needs the credentials; media access is guarded by the signed query inside each url. Downloads now run on a separate credential-free session.

## Why this is safe - measured, not assumed

A live access matrix on real **paid** posts (bare curl, no credentials):

| Request | Image | File | Audio |
|---|---|---|---|
| Bare url | 200 | 403 | 403 |
| Url + signed query | 200 | **200** | **200** |

- The signature alone is sufficient for protected media - no cookies, no token
- Audio and images did **not** carry the signature before this PR: paid audio survived only thanks to the shared session cookies. That is why the first commit signs image/audio urls like file urls - without it, the clean session would have broken paid audio
- (A Boosty quirk surfaced on the way: the image CDN serves paid images without any check at all - not ours to fix)

## Changes

1. `signed_query` reaches every media mapper (image/audio, files had it already); the domain golden pins the signature on all three kinds
2. `AppEnvironment` builds two sessions: authorized (API only, "Credentials live ONLY here") and a clean download session with the same timeouts/tracing/retries plus `DummyCookieJar` - it neither stores nor sends any cookie, so CDN redirects cannot attach anything
3. A wiring test through the real `AppEnvironment`: a local server asserts the API request arrives with `Authorization` + cookie and the media request arrives with neither

## Verification

- `task check` + `task test` green: **176 passed + 1 xfail**
- Live download of two real paid posts with the new build: image (real JPEG), 9 files including edge-case names, audio (real MP3) - all downloaded by the credential-free session
- Changelog: two entries under a new Security section
