### PR TITLE
chore: release v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.6.0
+
 ### Security
 
 - The account token and cookies no longer travel with media downloads: they went to every CDN and third-party video host with each downloaded file, though only the Boosty API needs them. Downloads now use a separate credential-free connection - access to protected media comes from the signed link itself

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boosty-downloader"
-version = "3.5.0"
+version = "3.6.0"
 description = "Download any type of content from boosty.to"
 authors = [{ name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "boosty-downloader"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Promotes the Unreleased changelog into v3.6.0 and bumps the version.

## Release notes

### Security

- The account token and cookies no longer travel with media downloads: they went to every CDN and third-party video host with each downloaded file, though only the Boosty API needs them. Downloads now use a separate credential-free connection - access to protected media comes from the signed link itself
- Images and audio now carry the same signed access query as files, so protected media downloads do not depend on session cookies

### Fixed

- `--post-url` now exits with code 1 when the post is not found, not accessible or fails to download, and with 130 on Ctrl+C - previously every failure looked like a success to scripts and cron
- A removed or restricted external video no longer crashes the run with a raw traceback - it is reported and written to failed_downloads.log like any other failed download
- A network timeout in the middle of a download is now reported as "Download timed out: the server stopped sending data" instead of the misleading "Failed during I/O operation" that pointed at the disk

## After merge

Run `task release:tag` - it verifies fresh main and pushes the tag; the tag triggers the release workflow (build -> PyPI -> GitHub Release).
