### PR TITLE
chore: release v3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.7.0
+
 ### Added
 
 - Media of a post now downloads up to 4 files at once instead of strictly one by one. The CDN caps the speed of every single connection, so image-heavy posts get up to ~10x faster and video posts 2-3x on a wide channel; the page layout, retries and Ctrl+C behave exactly as before

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "boosty-downloader"
-version = "3.6.0"
+version = "3.7.0"
 description = "Download any type of content from boosty.to"
 authors = [{ name = "Roman Berezkin", email = "Glitchy-Sheep@users.noreply.github.com" }]
 requires-python = ">=3.10,<4"

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ wheels = [
 
 [[package]]
 name = "boosty-downloader"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Promotes the Unreleased changelog into v3.7.0 and bumps the version.

## Release notes

### Added

- Media of a post now downloads up to 4 files at once instead of strictly one by one. The CDN caps the speed of every single connection, so image-heavy posts get up to ~10x faster and video posts 2-3x on a wide channel; the page layout, retries and Ctrl+C behave exactly as before
- External videos (yt-dlp) no longer freeze the progress display and other downloads while they run

## After merge

Run `task release:tag` - it verifies fresh main and pushes the tag; the tag triggers the release workflow (build -> PyPI -> GitHub Release).
