### PR TITLE
fix: add SSL certificate diagnostic to preflight (closes #174)

### DIFF
--- a/scripts/api_preflight.py
+++ b/scripts/api_preflight.py
@@ -10,9 +10,30 @@ from _integration_env import fetch_author_posts, load_config
 TITLE = 'test:api'
 
 
+import ssl
+import socket
+from datetime import datetime
+
 async def main() -> None:
     """Load the config and make one cheap live request; exit loudly when either fails."""
     config = load_config(TITLE)
+
+    # Diagnose SSL issues before making the request
+    try:
+        # Get the peer certificate to check its validity
+        ctx = ssl.create_default_context()
+        with socket.create_connection(('api.boosty.to', 443), timeout=10) as sock:
+            with ctx.wrap_socket(sock, server_hostname='api.boosty.to') as ssock:
+                cert = ssock.getpeercert()
+                not_after = datetime.strptime(cert['notAfter'], '%b %d %H:%M:%S %Y %Z')
+                if not_after < datetime.now():
+                    rich.print('[red]❌ Certificate for api.boosty.to expired at {}[/red]'.format(not_after))
+                else:
+                    rich.print('[yellow]⚠️ Certificate valid until {}. Proceeding.[/yellow]'.format(not_after))
+    except Exception as e:
+        rich.print('[red]❌ SSL diagnostic failed: {}[/red]'.format(e))
+        raise
+
     await fetch_author_posts(config, TITLE, limit=1)
     rich.print('[green]✅ Credentials are live - running the integration suite[/green]')
 


### PR DESCRIPTION
## What
When users encounter SSL certificate verification errors (e.g., #174), the current preflight script provides no helpful diagnostic. The error is often caused by an expired or untrusted certificate on the server or by a local proxy intercepting SSL.

## Fix
Add a pre-request SSL diagnostic step to `scripts/api_preflight.py` that connects to `api.boosty.to` and checks the peer certificate's expiry date. This will immediately show whether the server's certificate is expired, helping users and maintainers identify the root cause (server-side vs client-side).

The actual SSL verification logic in the main HTTP client is out of scope for this file, but this diagnostic provides a quick and actionable message.

Closes #174